### PR TITLE
PUBSUB Module tests & bug fixes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ volumes
 
 dist/
 src/modules/*/aof
+dump.rdb

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/echovault/echovault)](https://goreportcard.com/report/github.com/echovault/echovault)
 [![Go Coverage](https://github.com/EchoVault/EchoVault/wiki/coverage.svg)](https://raw.githack.com/wiki/EchoVault/EchoVault/coverage.html)
 [![GitHub Release](https://img.shields.io/github/v/release/EchoVault/EchoVault)]()
-<br/>
 [![License: GPL v3](https://img.shields.io/badge/License-GPL_v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
-<br/>
-[![Discord](https://img.shields.io/discord/1211815152291414037?style=flat&logo=discord&link=https%3A%2F%2Fdiscord.gg%2Fvt45CKfF)](https://discord.gg/vt45CKfF)
 
 <hr/>
 

--- a/src/aof/log/store.go
+++ b/src/aof/log/store.go
@@ -69,7 +69,7 @@ func NewAppendStore(options ...func(store *AppendStore)) *AppendStore {
 	}
 
 	// If rw is nil, use a default file at the provided directory
-	if store.rw == nil {
+	if store.rw == nil && store.directory != "" {
 		// Create the directory if it does not exist
 		err := os.MkdirAll(path.Join(store.directory, "aof"), os.ModePerm)
 		if err != nil {

--- a/src/aof/preamble/store.go
+++ b/src/aof/preamble/store.go
@@ -79,7 +79,7 @@ func NewPreambleStore(options ...func(store *PreambleStore)) *PreambleStore {
 	}
 
 	// If rw is nil, create the default
-	if store.rw == nil {
+	if store.rw == nil && store.directory != "" {
 		err := os.MkdirAll(path.Join(store.directory, "aof"), os.ModePerm)
 		if err != nil {
 			log.Println(fmt.Errorf("new preamble store -> mkdir error: %+v", err))

--- a/src/modules/acl/commands.go
+++ b/src/modules/acl/commands.go
@@ -502,7 +502,7 @@ func Commands() []utils.Command {
 				{
 					Command:     "users",
 					Categories:  []string{utils.AdminCategory, utils.SlowCategory, utils.DangerousCategory},
-					Description: "(ACL USERS) List all usersnames of the configured ACL users",
+					Description: "(ACL USERS) List all usernames of the configured ACL users",
 					Sync:        false,
 					KeyExtractionFunc: func(cmd []string) ([]string, error) {
 						return []string{}, nil

--- a/src/modules/acl/commands_test.go
+++ b/src/modules/acl/commands_test.go
@@ -1,0 +1,1 @@
+package acl

--- a/src/modules/acl/commands_test.go
+++ b/src/modules/acl/commands_test.go
@@ -1,1 +1,23 @@
 package acl
+
+import "testing"
+
+func Test_HandleAuth(t *testing.T) {}
+
+func Test_HandleCat(t *testing.T) {}
+
+func Test_HandleUsers(t *testing.T) {}
+
+func Test_HandleSetUser(t *testing.T) {}
+
+func Test_HandleGetUser(t *testing.T) {}
+
+func Test_HandleDelUser(t *testing.T) {}
+
+func Test_HandleWhoAmI(t *testing.T) {}
+
+func Test_HandleList(t *testing.T) {}
+
+func Test_HandleLoad(t *testing.T) {}
+
+func Test_HandleSave(t *testing.T) {}

--- a/src/modules/connection/commands_test.go
+++ b/src/modules/connection/commands_test.go
@@ -10,9 +10,19 @@ import (
 	"testing"
 )
 
+var mockServer *server.Server
+
+func init() {
+	mockServer = server.NewServer(server.Opts{
+		Config: utils.Config{
+			DataDir:        "",
+			EvictionPolicy: utils.NoEviction,
+		},
+	})
+}
+
 func Test_HandlePing(t *testing.T) {
 	ctx := context.Background()
-	mockServer := server.NewServer(server.Opts{})
 
 	tests := []struct {
 		command     []string

--- a/src/modules/generic/commands.go
+++ b/src/modules/generic/commands.go
@@ -22,9 +22,9 @@ func init() {
 		return
 	}
 	// Test run
+	now := time.Now()
 	timeNow = func() time.Time {
-		t, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z07:00")
-		return t
+		return now.Add(10 * time.Hour)
 	}
 }
 
@@ -397,7 +397,7 @@ func handleExpire(ctx context.Context, cmd []string, server utils.Server, _ *net
 		}
 		server.SetExpiry(ctx, key, expireAt, false)
 	default:
-		return nil, fmt.Errorf("unknown option %s", strings.ToUpper(cmd[0]))
+		return nil, fmt.Errorf("unknown option %s", strings.ToUpper(cmd[3]))
 	}
 
 	return []byte(":1\r\n"), nil
@@ -465,7 +465,7 @@ func handleExpireAt(ctx context.Context, cmd []string, server utils.Server, _ *n
 		}
 		server.SetExpiry(ctx, key, expireAt, false)
 	default:
-		return nil, fmt.Errorf("unknown option %s", strings.ToUpper(cmd[0]))
+		return nil, fmt.Errorf("unknown option %s", strings.ToUpper(cmd[3]))
 	}
 
 	return []byte(":1\r\n"), nil
@@ -517,7 +517,7 @@ PXAT - Expire at the exat time in unix milliseconds (positive integer).`,
 		{
 			Command:           "del",
 			Categories:        []string{utils.KeyspaceCategory, utils.WriteCategory, utils.FastCategory},
-			Description:       "(DEL) Removes one or more keys from the store.",
+			Description:       "(DEL key [key ...]) Removes one or more keys from the store.",
 			Sync:              true,
 			KeyExtractionFunc: delKeyFunc,
 			HandlerFunc:       handleDel,
@@ -578,8 +578,8 @@ If the key does not exist, -2 is returned.`,
 Expire the key in the specified number of seconds. This commands turns a key into a volatile one.
 NX - Only set the expiry time if the key has no associated expiry.
 XX - Only set the expiry time if the key already has an expiry time.
-GT - Only set the expiry time if the current expiry time is greater than the specified expiry time.
-LT - Only set the expiry time if the current expiry time is less than the specified expiry time.`,
+GT - Only set the expiry time if the new expiry time is greater than the current one.
+LT - Only set the expiry time if the new expiry time is less than the current one.`,
 			Sync:              true,
 			KeyExtractionFunc: expireKeyFunc,
 			HandlerFunc:       handleExpire,
@@ -591,8 +591,8 @@ LT - Only set the expiry time if the current expiry time is less than the specif
 Expire the key in the specified number of milliseconds. This commands turns a key into a volatile one.
 NX - Only set the expiry time if the key has no associated expiry.
 XX - Only set the expiry time if the key already has an expiry time.
-GT - Only set the expiry time if the current expiry time is greater than the specified expiry time.
-LT - Only set the expiry time if the current expiry time is less than the specified expiry time.`,
+GT - Only set the expiry time if the new expiry time is greater than the current one.
+LT - Only set the expiry time if the new expiry time is less than the current one.`,
 			Sync:              true,
 			KeyExtractionFunc: expireKeyFunc,
 			HandlerFunc:       handleExpire,
@@ -605,8 +605,8 @@ Expire the key in at the exact unix time in seconds.
 This commands turns a key into a volatile one.
 NX - Only set the expiry time if the key has no associated expiry.
 XX - Only set the expiry time if the key already has an expiry time.
-GT - Only set the expiry time if the current expiry time is greater than the specified expiry time.
-LT - Only set the expiry time if the current expiry time is less than the specified expiry time.`,
+GT - Only set the expiry time if the new expiry time is greater than the current one.
+LT - Only set the expiry time if the new expiry time is less than the current one.`,
 			Sync:              true,
 			KeyExtractionFunc: expireAtKeyFunc,
 			HandlerFunc:       handleExpireAt,
@@ -619,8 +619,8 @@ Expire the key in at the exact unix time in milliseconds.
 This commands turns a key into a volatile one.
 NX - Only set the expiry time if the key has no associated expiry.
 XX - Only set the expiry time if the key already has an expiry time.
-GT - Only set the expiry time if the current expiry time is greater than the specified expiry time.
-LT - Only set the expiry time if the current expiry time is less than the specified expiry time.`,
+GT - Only set the expiry time if the new expiry time is greater than the current one.
+LT - Only set the expiry time if the new expiry time is less than the current one.`,
 			Sync:              true,
 			KeyExtractionFunc: expireAtKeyFunc,
 			HandlerFunc:       handleExpireAt,

--- a/src/modules/generic/commands_test.go
+++ b/src/modules/generic/commands_test.go
@@ -9,331 +9,355 @@ import (
 	"github.com/echovault/echovault/src/utils"
 	"github.com/tidwall/resp"
 	"testing"
+	"time"
 )
 
 func Test_HandleSET(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
+	mockServer := server.NewServer(server.Opts{
+		Config: utils.Config{
+			EvictionPolicy: utils.NoEviction,
+		},
+	})
 
 	tests := []struct {
 		command          []string
-		expectedResponse string
+		presetValues     map[string]utils.KeyData
+		expectedResponse interface{}
 		expectedValue    interface{}
+		expectedExpiry   time.Time
 		expectedErr      error
 	}{
-		{
-			command:          []string{"SET", "test", "value"},
+		{ // 1. Set normal string value
+			command:          []string{"SET", "key1", "value1"},
+			presetValues:     nil,
 			expectedResponse: "OK",
-			expectedValue:    "value",
+			expectedValue:    "value1",
+			expectedExpiry:   time.Time{},
 			expectedErr:      nil,
 		},
-		{
-			command:          []string{"SET", "integer", "1245678910"},
+		{ // 2. Set normal integer value
+			command:          []string{"SET", "key2", "1245678910"},
+			presetValues:     nil,
 			expectedResponse: "OK",
 			expectedValue:    1245678910,
+			expectedExpiry:   time.Time{},
 			expectedErr:      nil,
 		},
-		{
-			command:          []string{"SET", "float", "45782.11341"},
+		{ // 3. Set normal float value
+			command:          []string{"SET", "key3", "45782.11341"},
+			presetValues:     nil,
 			expectedResponse: "OK",
 			expectedValue:    45782.11341,
+			expectedExpiry:   time.Time{},
 			expectedErr:      nil,
 		},
-		{
-			command:          []string{"SET"},
-			expectedResponse: "",
-			expectedValue:    nil,
-			expectedErr:      errors.New(utils.WrongArgsResponse),
-		},
-		{
-			command:          []string{"SET", "test", "one", "two", "three", "four", "five", "eight"},
-			expectedResponse: "",
-			expectedValue:    nil,
-			expectedErr:      errors.New(utils.WrongArgsResponse),
-		},
-	}
-
-	for _, test := range tests {
-		res, err := handleSet(context.Background(), test.command, mockServer, nil)
-		if test.expectedErr != nil {
-			if err.Error() != test.expectedErr.Error() {
-				t.Errorf("expected error %s, got %s", test.expectedErr.Error(), err.Error())
-			}
-			continue
-		}
-		if err != nil {
-			t.Error(err)
-		}
-		rd := resp.NewReader(bytes.NewBuffer(res))
-		rv, _, err := rd.ReadValue()
-		if err != nil {
-			t.Error(err)
-		}
-		if rv.String() != test.expectedResponse {
-			t.Errorf("expected response %s, got %s", test.expectedResponse, rv.String())
-		}
-		value := mockServer.GetValue(context.Background(), test.command[1])
-		switch value.(type) {
-		default:
-			t.Error("unexpected type for expectedValue")
-		case int:
-			testValue, ok := test.expectedValue.(int)
-			if !ok {
-				t.Error("expected integer value but got another type")
-			}
-			if value != testValue {
-				t.Errorf("expected value %d, got: %d", testValue, value)
-			}
-		case float64:
-			testValue, ok := test.expectedValue.(float64)
-			if !ok {
-				t.Error("expected float value but got another type")
-			}
-			if value != testValue {
-				t.Errorf("expected value %f, got: %f", testValue, value)
-			}
-		case string:
-			testValue, ok := test.expectedValue.(string)
-			if !ok {
-				t.Error("expected string value but got another type")
-			}
-			if value != testValue {
-				t.Errorf("expected value %s, got: %s", testValue, value)
-			}
-		}
-	}
-}
-
-func Test_HandleMSET(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
-	tests := []struct {
-		command          []string
-		expectedResponse string
-		expectedValues   map[string]interface{}
-		expectedErr      error
-	}{
-		{
-			command:          []string{"SET", "test1", "value1", "test2", "10", "test3", "3.142"},
+		{ // 4. Only set the value if the key does not exist
+			command:          []string{"SET", "key4", "value4", "NX"},
+			presetValues:     nil,
 			expectedResponse: "OK",
-			expectedValues:   map[string]interface{}{"test1": "value1", "test2": 10, "test3": 3.142},
+			expectedValue:    "value4",
+			expectedExpiry:   time.Time{},
 			expectedErr:      nil,
 		},
-		{
-			command:          []string{"SET", "test1", "value1", "test2", "10", "test3"},
-			expectedResponse: "",
-			expectedValues:   make(map[string]interface{}),
-			expectedErr:      errors.New("each key must be paired with a value"),
+		{ // 5. Throw error when value already exists with NX flag passed
+			command: []string{"SET", "key5", "value5", "NX"},
+			presetValues: map[string]utils.KeyData{
+				"key5": {
+					Value:    "preset-value5",
+					ExpireAt: time.Time{},
+				},
+			},
+			expectedResponse: nil,
+			expectedValue:    "preset-value5",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("key key5 already exists"),
+		},
+		{ // 6. Set new key value when key exists with XX flag passed
+			command: []string{"SET", "key6", "value6", "XX"},
+			presetValues: map[string]utils.KeyData{
+				"key6": {
+					Value:    "preset-value6",
+					ExpireAt: time.Time{},
+				},
+			},
+			expectedResponse: "OK",
+			expectedValue:    "value6",
+			expectedExpiry:   time.Time{},
+			expectedErr:      nil,
+		},
+		{ // 7. Return error when setting non-existent key with XX flag
+			command:          []string{"SET", "key7", "value7", "XX"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("key key7 does not exist"),
+		},
+		{ // 8. Return error when NX flag is provided after XX flag
+			command:          []string{"SET", "key8", "value8", "XX", "NX"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("cannot specify NX when XX is already specified"),
+		},
+		{ // 9. Return error when XX flag is provided after NX flag
+			command:          []string{"SET", "key9", "value9", "NX", "XX"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("cannot specify XX when NX is already specified"),
+		},
+		{ // 10. Set expiry time on the key to 100 seconds from now
+			command:          []string{"SET", "key10", "value10", "EX", "100"},
+			presetValues:     nil,
+			expectedResponse: "OK",
+			expectedValue:    "value10",
+			expectedExpiry:   timeNow().Add(100 * time.Second),
+			expectedErr:      nil,
+		},
+		{ // 11. Return error when EX flag is passed without seconds value
+			command:          []string{"SET", "key11", "value11", "EX"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("seconds value required after EX"),
+		},
+		{ // 12. Return error when EX flag is passed with invalid (non-integer) value
+			command:          []string{"SET", "key12", "value12", "EX", "seconds"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("seconds value should be an integer"),
+		},
+		{ // 13. Return error when trying to set expiry seconds when expiry is already set
+			command:          []string{"SET", "key13", "value13", "PX", "100000", "EX", "100"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("cannot specify EX when expiry time is already set"),
+		},
+		{ // 14. Set expiry time on the key in unix milliseconds
+			command:          []string{"SET", "key14", "value14", "PX", "4096"},
+			presetValues:     nil,
+			expectedResponse: "OK",
+			expectedValue:    "value14",
+			expectedExpiry:   timeNow().Add(4096 * time.Millisecond),
+			expectedErr:      nil,
+		},
+		{ // 15. Return error when PX flag is passed without milliseconds value
+			command:          []string{"SET", "key15", "value15", "PX"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("milliseconds value required after PX"),
+		},
+		{ // 16. Return error when PX flag is passed with invalid (non-integer) value
+			command:          []string{"SET", "key16", "value16", "PX", "milliseconds"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("milliseconds value should be an integer"),
+		},
+		{ // 17. Return error when trying to set expiry milliseconds when expiry is already provided
+			command:          []string{"SET", "key17", "value17", "EX", "10", "PX", "1000000"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("cannot specify PX when expiry time is already set"),
+		},
+		{ // 18. Set exact expiry time in seconds from unix epoch
+			command: []string{
+				"SET", "key18", "value18",
+				"EXAT", fmt.Sprintf("%d", timeNow().Add(200*time.Second).Unix()),
+			},
+			presetValues:     nil,
+			expectedResponse: "OK",
+			expectedValue:    "value18",
+			expectedExpiry:   timeNow().Add(200 * time.Second),
+			expectedErr:      nil,
+		},
+		{ // 19. Return error when trying to set exact seconds expiry time when expiry time is already provided
+			command: []string{
+				"SET", "key19", "value19",
+				"EX", "10",
+				"EXAT", fmt.Sprintf("%d", timeNow().Add(200*time.Second).Unix()),
+			},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("cannot specify EXAT when expiry time is already set"),
+		},
+		{ // 20. Return error when no seconds value is provided after EXAT flag
+			command:          []string{"SET", "key20", "value20", "EXAT"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("seconds value required after EXAT"),
+		},
+		{ // 21. Return error when invalid (non-integer) value is passed after EXAT flag
+			command:          []string{"SET", "key21", "value21", "EXAT", "seconds"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("seconds value should be an integer"),
+		},
+		{ // 22. Set exact expiry time in milliseconds from unix epoch
+			command: []string{
+				"SET", "key22", "value22",
+				"PXAT", fmt.Sprintf("%d", timeNow().Add(4096*time.Millisecond).UnixMilli()),
+			},
+			presetValues:     nil,
+			expectedResponse: "OK",
+			expectedValue:    "value22",
+			expectedExpiry:   timeNow().Add(4096 * time.Millisecond),
+			expectedErr:      nil,
+		},
+		{ // 23. Return error when trying to set exact milliseconds expiry time when expiry time is already provided
+			command: []string{
+				"SET", "key23", "value23",
+				"PX", "1000",
+				"PXAT", fmt.Sprintf("%d", timeNow().Add(4096*time.Millisecond).UnixMilli()),
+			},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("cannot specify PXAT when expiry time is already set"),
+		},
+		{ // 24. Return error when no milliseconds value is provided after PXAT flag
+			command:          []string{"SET", "key24", "value24", "PXAT"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("milliseconds value required after PXAT"),
+		},
+		{ // 25. Return error when invalid (non-integer) value is passed after EXAT flag
+			command:          []string{"SET", "key25", "value25", "PXAT", "unix-milliseconds"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "",
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("milliseconds value should be an integer"),
+		},
+		{ // 26. Get the previous value when GET flag is passed
+			command: []string{"SET", "key26", "value26", "GET", "EX", "1000"},
+			presetValues: map[string]utils.KeyData{
+				"key26": {
+					Value:    "previous-value",
+					ExpireAt: time.Time{},
+				},
+			},
+			expectedResponse: "previous-value",
+			expectedValue:    "value26",
+			expectedExpiry:   timeNow().Add(1000 * time.Second),
+			expectedErr:      nil,
+		},
+		{ // 27. Return nil when GET value is passed and no previous value exists
+			command:          []string{"SET", "key27", "value27", "GET", "EX", "1000"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    "value27",
+			expectedExpiry:   timeNow().Add(1000 * time.Second),
+			expectedErr:      nil,
+		},
+		{ // 28. Throw error when unknown optional flag is passed to SET command.
+			command:          []string{"SET", "key28", "value28", "UNKNOWN-OPTION"},
+			presetValues:     nil,
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedExpiry:   time.Time{},
+			expectedErr:      errors.New("unknown option UNKNOWN-OPTION for set command"),
+		},
+		{ // 29. Command too short
+			command:          []string{"SET"},
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedErr:      errors.New(utils.WrongArgsResponse),
+		},
+		{ // 30. Command too long
+			command:          []string{"SET", "key", "value1", "value2", "value3", "value4", "value5", "value6"},
+			expectedResponse: nil,
+			expectedValue:    nil,
+			expectedErr:      errors.New(utils.WrongArgsResponse),
 		},
 	}
 
-	for _, test := range tests {
-		res, err := handleMSet(context.Background(), test.command, mockServer, nil)
+	for i, test := range tests {
+		ctx := context.WithValue(context.Background(), "test_name", fmt.Sprintf("SET, %d", i))
+
+		if test.presetValues != nil {
+			for k, v := range test.presetValues {
+				if _, err := mockServer.CreateKeyAndLock(ctx, k); err != nil {
+					t.Error(err)
+				}
+				if err := mockServer.SetValue(ctx, k, v.Value); err != nil {
+					t.Error(err)
+				}
+				mockServer.SetExpiry(ctx, k, v.ExpireAt, false)
+				mockServer.KeyUnlock(ctx, k)
+			}
+		}
+
+		res, err := handleSet(ctx, test.command, mockServer, nil)
+
 		if test.expectedErr != nil {
-			if err.Error() != test.expectedErr.Error() {
-				t.Errorf("expected error %s, got %s", test.expectedErr.Error(), err.Error())
+			if err == nil {
+				t.Errorf("expected error \"%s\", got nil", test.expectedErr.Error())
+			}
+			if test.expectedErr.Error() != err.Error() {
+				t.Errorf("expected error \"%s\", got \"%s\"", test.expectedErr.Error(), err.Error())
 			}
 			continue
 		}
-		rd := resp.NewReader(bytes.NewBuffer(res))
+
+		rd := resp.NewReader(bytes.NewReader(res))
 		rv, _, err := rd.ReadValue()
 		if err != nil {
 			t.Error(err)
 		}
-		if rv.String() != test.expectedResponse {
-			t.Errorf("expected response %s, got %s", test.expectedResponse, rv.String())
+
+		switch test.expectedResponse.(type) {
+		case string:
+			if test.expectedResponse != rv.String() {
+				t.Errorf("expected response \"%s\", got \"%s\"", test.expectedResponse, rv.String())
+			}
+		case nil:
+			if !rv.IsNull() {
+				t.Errorf("expcted nil response, got %+v", rv)
+			}
+		default:
+			t.Error("test expected result should be nil or string")
 		}
-		for key, expectedValue := range test.expectedValues {
-			if _, err = mockServer.KeyRLock(context.Background(), key); err != nil {
-				t.Error(err)
-			}
-			switch expectedValue.(type) {
-			default:
-				t.Error("unexpected type for expectedValue")
-			case int:
-				ev, _ := expectedValue.(int)
-				value, ok := mockServer.GetValue(context.Background(), key).(int)
-				if !ok {
-					t.Errorf("expected integer type for key %s, got another type", key)
-				}
-				if value != ev {
-					t.Errorf("expected value %d for key %s, got %d", ev, key, value)
-				}
-			case float64:
-				ev, _ := expectedValue.(float64)
-				value, ok := mockServer.GetValue(context.Background(), key).(float64)
-				if !ok {
-					t.Errorf("expected float type for key %s, got another type", key)
-				}
-				if value != ev {
-					t.Errorf("expected value %f for key %s, got %f", ev, key, value)
-				}
-			case string:
-				ev, _ := expectedValue.(string)
-				value, ok := mockServer.GetValue(context.Background(), key).(string)
-				if !ok {
-					t.Errorf("expected string type for key %s, got another type", key)
-				}
-				if value != ev {
-					t.Errorf("expected value %s for key %s, got %s", ev, key, value)
-				}
-			}
-			mockServer.KeyRUnlock(context.Background(), key)
-		}
-	}
-}
 
-func Test_HandleGET(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
+		// Compare expected value and expected time
+		key := test.command[1]
+		var value interface{}
+		var expireAt time.Time
 
-	tests := []struct {
-		key   string
-		value string
-	}{
-		{
-			key:   "test1",
-			value: "value1",
-		},
-		{
-			key:   "test2",
-			value: "10",
-		},
-		{
-			key:   "test3",
-			value: "3.142",
-		},
-	}
-	// Test successful GET command
-	for _, test := range tests {
-		func(key, value string) {
-			ctx := context.Background()
-
-			_, err := mockServer.CreateKeyAndLock(ctx, key)
-			if err != nil {
-				t.Error(err)
-			}
-			if err = mockServer.SetValue(ctx, key, value); err != nil {
-				t.Error(err)
-			}
-			mockServer.KeyUnlock(ctx, key)
-
-			res, err := handleGet(ctx, []string{"GET", key}, mockServer, nil)
-			if err != nil {
-				t.Error(err)
-			}
-			if !bytes.Equal(res, []byte(fmt.Sprintf("+%v\r\n", value))) {
-				t.Errorf("expected %s, got: %s", fmt.Sprintf("+%v\r\n", value), string(res))
-			}
-		}(test.key, test.value)
-	}
-
-	// Test get non-existent key
-	res, err := handleGet(context.Background(), []string{"GET", "test4"}, mockServer, nil)
-	if err != nil {
-		t.Error(err)
-	}
-	if !bytes.Equal(res, []byte("$-1\r\n")) {
-		t.Errorf("expected %+v, got: %+v", "+nil\r\n", res)
-	}
-
-	errorTests := []struct {
-		command  []string
-		expected string
-	}{
-		{
-			command:  []string{"GET"},
-			expected: utils.WrongArgsResponse,
-		},
-		{
-			command:  []string{"GET", "key", "test"},
-			expected: utils.WrongArgsResponse,
-		},
-	}
-	for _, test := range errorTests {
-		res, err = handleGet(context.Background(), test.command, mockServer, nil)
-		if res != nil {
-			t.Errorf("expected nil response, got: %+v", res)
-		}
-		if err.Error() != test.expected {
-			t.Errorf("expected error '%s', got: %s", test.expected, err.Error())
-		}
-	}
-}
-
-func Test_HandleMGET(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
-	tests := []struct {
-		presetKeys    []string
-		presetValues  []string
-		command       []string
-		expected      []interface{}
-		expectedError error
-	}{
-		{
-			presetKeys:    []string{"test1", "test2", "test3", "test4"},
-			presetValues:  []string{"value1", "value2", "value3", "value4"},
-			command:       []string{"MGET", "test1", "test4", "test2", "test3", "test1"},
-			expected:      []interface{}{"value1", "value4", "value2", "value3", "value1"},
-			expectedError: nil,
-		},
-		{
-			presetKeys:    []string{"test5", "test6", "test7"},
-			presetValues:  []string{"value5", "value6", "value7"},
-			command:       []string{"MGET", "test5", "test6", "non-existent", "non-existent", "test7", "non-existent"},
-			expected:      []interface{}{"value5", "value6", nil, nil, "value7", nil},
-			expectedError: nil,
-		},
-		{
-			presetKeys:    []string{"test5"},
-			presetValues:  []string{"value5"},
-			command:       []string{"MGET"},
-			expected:      nil,
-			expectedError: errors.New(utils.WrongArgsResponse),
-		},
-	}
-
-	for _, test := range tests {
-		// Set up the values
-		for i, key := range test.presetKeys {
-			_, err := mockServer.CreateKeyAndLock(context.Background(), key)
-			if err != nil {
-				t.Error(err)
-			}
-			if err = mockServer.SetValue(context.Background(), key, test.presetValues[i]); err != nil {
-				t.Error(err)
-			}
-			mockServer.KeyUnlock(context.Background(), key)
-		}
-		// Test the command and its results
-		res, err := handleMGet(context.Background(), test.command, mockServer, nil)
-		if test.expectedError != nil {
-			// If we expect and error, branch out and check error
-			if err.Error() != test.expectedError.Error() {
-				t.Errorf("expected error %+v, got: %+v", test.expectedError, err)
-			}
-			continue
-		}
-		if err != nil {
+		if _, err = mockServer.KeyLock(ctx, key); err != nil {
 			t.Error(err)
 		}
-		rr := resp.NewReader(bytes.NewBuffer(res))
-		rv, _, err := rr.ReadValue()
-		if err != nil {
-			t.Error(err)
+		value = mockServer.GetValue(ctx, key)
+		expireAt = mockServer.GetExpiry(ctx, key)
+		mockServer.KeyUnlock(ctx, key)
+
+		if value != test.expectedValue {
+			t.Errorf("expected value %+v, got %+v", test.expectedValue, value)
 		}
-		if rv.Type().String() != "Array" {
-			t.Errorf("expected type Array, got: %s", rv.Type().String())
-		}
-		for i, value := range rv.Array() {
-			if test.expected[i] == nil {
-				if !value.IsNull() {
-					t.Errorf("expected nil value, got %+v", value)
-				}
-				continue
-			}
-			if value.String() != test.expected[i] {
-				t.Errorf("expected value %s, got: %s", test.expected[i], value.String())
-			}
+		if test.expectedExpiry.Unix() != expireAt.Unix() {
+			t.Errorf("expected expiry time %d, got %d", test.expectedExpiry.Unix(), expireAt.Unix())
 		}
 	}
 }

--- a/src/modules/generic/commands_test.go
+++ b/src/modules/generic/commands_test.go
@@ -361,3 +361,238 @@ func Test_HandleSET(t *testing.T) {
 		}
 	}
 }
+
+func Test_HandleMSET(t *testing.T) {
+	mockServer := server.NewServer(server.Opts{})
+
+	tests := []struct {
+		command          []string
+		expectedResponse string
+		expectedValues   map[string]interface{}
+		expectedErr      error
+	}{
+		{
+			command:          []string{"SET", "test1", "value1", "test2", "10", "test3", "3.142"},
+			expectedResponse: "OK",
+			expectedValues:   map[string]interface{}{"test1": "value1", "test2": 10, "test3": 3.142},
+			expectedErr:      nil,
+		},
+		{
+			command:          []string{"SET", "test1", "value1", "test2", "10", "test3"},
+			expectedResponse: "",
+			expectedValues:   make(map[string]interface{}),
+			expectedErr:      errors.New("each key must be paired with a value"),
+		},
+	}
+
+	for _, test := range tests {
+		res, err := handleMSet(context.Background(), test.command, mockServer, nil)
+		if test.expectedErr != nil {
+			if err.Error() != test.expectedErr.Error() {
+				t.Errorf("expected error %s, got %s", test.expectedErr.Error(), err.Error())
+			}
+			continue
+		}
+		rd := resp.NewReader(bytes.NewBuffer(res))
+		rv, _, err := rd.ReadValue()
+		if err != nil {
+			t.Error(err)
+		}
+		if rv.String() != test.expectedResponse {
+			t.Errorf("expected response %s, got %s", test.expectedResponse, rv.String())
+		}
+		for key, expectedValue := range test.expectedValues {
+			if _, err = mockServer.KeyRLock(context.Background(), key); err != nil {
+				t.Error(err)
+			}
+			switch expectedValue.(type) {
+			default:
+				t.Error("unexpected type for expectedValue")
+			case int:
+				ev, _ := expectedValue.(int)
+				value, ok := mockServer.GetValue(context.Background(), key).(int)
+				if !ok {
+					t.Errorf("expected integer type for key %s, got another type", key)
+				}
+				if value != ev {
+					t.Errorf("expected value %d for key %s, got %d", ev, key, value)
+				}
+			case float64:
+				ev, _ := expectedValue.(float64)
+				value, ok := mockServer.GetValue(context.Background(), key).(float64)
+				if !ok {
+					t.Errorf("expected float type for key %s, got another type", key)
+				}
+				if value != ev {
+					t.Errorf("expected value %f for key %s, got %f", ev, key, value)
+				}
+			case string:
+				ev, _ := expectedValue.(string)
+				value, ok := mockServer.GetValue(context.Background(), key).(string)
+				if !ok {
+					t.Errorf("expected string type for key %s, got another type", key)
+				}
+				if value != ev {
+					t.Errorf("expected value %s for key %s, got %s", ev, key, value)
+				}
+			}
+			mockServer.KeyRUnlock(context.Background(), key)
+		}
+	}
+}
+
+func Test_HandleGET(t *testing.T) {
+	mockServer := server.NewServer(server.Opts{})
+
+	tests := []struct {
+		key   string
+		value string
+	}{
+		{
+			key:   "test1",
+			value: "value1",
+		},
+		{
+			key:   "test2",
+			value: "10",
+		},
+		{
+			key:   "test3",
+			value: "3.142",
+		},
+	}
+	// Test successful GET command
+	for _, test := range tests {
+		func(key, value string) {
+			ctx := context.Background()
+
+			_, err := mockServer.CreateKeyAndLock(ctx, key)
+			if err != nil {
+				t.Error(err)
+			}
+			if err = mockServer.SetValue(ctx, key, value); err != nil {
+				t.Error(err)
+			}
+			mockServer.KeyUnlock(ctx, key)
+
+			res, err := handleGet(ctx, []string{"GET", key}, mockServer, nil)
+			if err != nil {
+				t.Error(err)
+			}
+			if !bytes.Equal(res, []byte(fmt.Sprintf("+%v\r\n", value))) {
+				t.Errorf("expected %s, got: %s", fmt.Sprintf("+%v\r\n", value), string(res))
+			}
+		}(test.key, test.value)
+	}
+
+	// Test get non-existent key
+	res, err := handleGet(context.Background(), []string{"GET", "test4"}, mockServer, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(res, []byte("$-1\r\n")) {
+		t.Errorf("expected %+v, got: %+v", "+nil\r\n", res)
+	}
+
+	errorTests := []struct {
+		command  []string
+		expected string
+	}{
+		{
+			command:  []string{"GET"},
+			expected: utils.WrongArgsResponse,
+		},
+		{
+			command:  []string{"GET", "key", "test"},
+			expected: utils.WrongArgsResponse,
+		},
+	}
+	for _, test := range errorTests {
+		res, err = handleGet(context.Background(), test.command, mockServer, nil)
+		if res != nil {
+			t.Errorf("expected nil response, got: %+v", res)
+		}
+		if err.Error() != test.expected {
+			t.Errorf("expected error '%s', got: %s", test.expected, err.Error())
+		}
+	}
+}
+
+func Test_HandleMGET(t *testing.T) {
+	mockServer := server.NewServer(server.Opts{})
+
+	tests := []struct {
+		presetKeys    []string
+		presetValues  []string
+		command       []string
+		expected      []interface{}
+		expectedError error
+	}{
+		{
+			presetKeys:    []string{"test1", "test2", "test3", "test4"},
+			presetValues:  []string{"value1", "value2", "value3", "value4"},
+			command:       []string{"MGET", "test1", "test4", "test2", "test3", "test1"},
+			expected:      []interface{}{"value1", "value4", "value2", "value3", "value1"},
+			expectedError: nil,
+		},
+		{
+			presetKeys:    []string{"test5", "test6", "test7"},
+			presetValues:  []string{"value5", "value6", "value7"},
+			command:       []string{"MGET", "test5", "test6", "non-existent", "non-existent", "test7", "non-existent"},
+			expected:      []interface{}{"value5", "value6", nil, nil, "value7", nil},
+			expectedError: nil,
+		},
+		{
+			presetKeys:    []string{"test5"},
+			presetValues:  []string{"value5"},
+			command:       []string{"MGET"},
+			expected:      nil,
+			expectedError: errors.New(utils.WrongArgsResponse),
+		},
+	}
+
+	for _, test := range tests {
+		// Set up the values
+		for i, key := range test.presetKeys {
+			_, err := mockServer.CreateKeyAndLock(context.Background(), key)
+			if err != nil {
+				t.Error(err)
+			}
+			if err = mockServer.SetValue(context.Background(), key, test.presetValues[i]); err != nil {
+				t.Error(err)
+			}
+			mockServer.KeyUnlock(context.Background(), key)
+		}
+		// Test the command and its results
+		res, err := handleMGet(context.Background(), test.command, mockServer, nil)
+		if test.expectedError != nil {
+			// If we expect and error, branch out and check error
+			if err.Error() != test.expectedError.Error() {
+				t.Errorf("expected error %+v, got: %+v", test.expectedError, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Error(err)
+		}
+		rr := resp.NewReader(bytes.NewBuffer(res))
+		rv, _, err := rr.ReadValue()
+		if err != nil {
+			t.Error(err)
+		}
+		if rv.Type().String() != "Array" {
+			t.Errorf("expected type Array, got: %s", rv.Type().String())
+		}
+		for i, value := range rv.Array() {
+			if test.expected[i] == nil {
+				if !value.IsNull() {
+					t.Errorf("expected nil value, got %+v", value)
+				}
+				continue
+			}
+			if value.String() != test.expected[i] {
+				t.Errorf("expected value %s, got: %s", test.expected[i], value.String())
+			}
+		}
+	}
+}

--- a/src/modules/generic/utils.go
+++ b/src/modules/generic/utils.go
@@ -47,14 +47,14 @@ func getSetCommandParams(cmd []string, params SetParams) (SetParams, error) {
 		secondsStr := cmd[1]
 		seconds, err := strconv.ParseInt(secondsStr, 10, 64)
 		if err != nil {
-			return SetParams{}, err
+			return SetParams{}, errors.New("seconds value should be an integer")
 		}
 		params.expireAt = time.Now().Add(time.Duration(seconds) * time.Second)
 		return getSetCommandParams(cmd[2:], params)
 
 	case "px":
 		if len(cmd) < 2 {
-			return SetParams{}, errors.New("seconds value required after PX")
+			return SetParams{}, errors.New("milliseconds value required after PX")
 		}
 		if params.expireAt != nil {
 			return SetParams{}, errors.New("cannot specify PX when expiry time is already set")
@@ -62,7 +62,7 @@ func getSetCommandParams(cmd []string, params SetParams) (SetParams, error) {
 		millisecondsStr := cmd[1]
 		milliseconds, err := strconv.ParseInt(millisecondsStr, 10, 64)
 		if err != nil {
-			return SetParams{}, err
+			return SetParams{}, errors.New("milliseconds value should be an integer")
 		}
 		params.expireAt = time.Now().Add(time.Duration(milliseconds) * time.Millisecond)
 		return getSetCommandParams(cmd[2:], params)
@@ -77,14 +77,14 @@ func getSetCommandParams(cmd []string, params SetParams) (SetParams, error) {
 		secondsStr := cmd[1]
 		seconds, err := strconv.ParseInt(secondsStr, 10, 64)
 		if err != nil {
-			return SetParams{}, err
+			return SetParams{}, errors.New("seconds value should be an integer")
 		}
 		params.expireAt = time.Unix(seconds, 0)
 		return getSetCommandParams(cmd[2:], params)
 
 	case "pxat":
 		if len(cmd) < 2 {
-			return SetParams{}, errors.New("seconds value required after PXAT")
+			return SetParams{}, errors.New("milliseconds value required after PXAT")
 		}
 		if params.expireAt != nil {
 			return SetParams{}, errors.New("cannot specify PXAT when expiry time is already set")
@@ -92,7 +92,7 @@ func getSetCommandParams(cmd []string, params SetParams) (SetParams, error) {
 		millisecondsStr := cmd[1]
 		milliseconds, err := strconv.ParseInt(millisecondsStr, 10, 64)
 		if err != nil {
-			return SetParams{}, err
+			return SetParams{}, errors.New("milliseconds value should be an integer")
 		}
 		params.expireAt = time.UnixMilli(milliseconds)
 		return getSetCommandParams(cmd[2:], params)

--- a/src/modules/hash/commands_test.go
+++ b/src/modules/hash/commands_test.go
@@ -12,10 +12,19 @@ import (
 	"testing"
 )
 
+var mockServer *server.Server
+
+func init() {
+	mockServer = server.NewServer(server.Opts{
+		Config: utils.Config{
+			DataDir:        "",
+			EvictionPolicy: utils.NoEviction,
+		},
+	})
+}
+
 func Test_HandleHSET(t *testing.T) {
 	// Tests for both HSET and HSETNX
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -27,70 +36,70 @@ func Test_HandleHSET(t *testing.T) {
 	}{
 		{ // HSETNX set field on non-existent hash map
 			preset:           false,
-			key:              "key1",
+			key:              "HsetKey1",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HSETNX", "key1", "field1", "value1"},
+			command:          []string{"HSETNX", "HsetKey1", "field1", "value1"},
 			expectedResponse: 1,
 			expectedValue:    map[string]interface{}{"field1": "value1"},
 			expectedError:    nil,
 		},
 		{ // HSETNX set field on existing hash map
 			preset:           true,
-			key:              "key2",
+			key:              "HsetKey2",
 			presetValue:      map[string]interface{}{"field1": "value1"},
-			command:          []string{"HSETNX", "key2", "field2", "value2"},
+			command:          []string{"HSETNX", "HsetKey2", "field2", "value2"},
 			expectedResponse: 1,
 			expectedValue:    map[string]interface{}{"field1": "value1", "field2": "value2"},
 			expectedError:    nil,
 		},
 		{ // HSETNX skips operation when setting on existing field
 			preset:           true,
-			key:              "key3",
+			key:              "HsetKey3",
 			presetValue:      map[string]interface{}{"field1": "value1"},
-			command:          []string{"HSETNX", "key3", "field1", "value1-new"},
+			command:          []string{"HSETNX", "HsetKey3", "field1", "value1-new"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{"field1": "value1"},
 			expectedError:    nil,
 		},
 		{ // Regular HSET command on non-existent hash map
 			preset:           false,
-			key:              "key4",
+			key:              "HsetKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HSET", "key4", "field1", "value1", "field2", "value2"},
+			command:          []string{"HSET", "HsetKey4", "field1", "value1", "field2", "value2"},
 			expectedResponse: 2,
 			expectedValue:    map[string]interface{}{"field1": "value1", "field2": "value2"},
 			expectedError:    nil,
 		},
 		{ // Regular HSET update on existing hash map
 			preset:           true,
-			key:              "key5",
+			key:              "HsetKey5",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": "value2"},
-			command:          []string{"HSET", "key5", "field1", "value1-new", "field2", "value2-ne2", "field3", "value3"},
+			command:          []string{"HSET", "HsetKey5", "field1", "value1-new", "field2", "value2-ne2", "field3", "value3"},
 			expectedResponse: 3,
 			expectedValue:    map[string]interface{}{"field1": "value1-new", "field2": "value2-ne2", "field3": "value3"},
 			expectedError:    nil,
 		},
 		{ // HSET returns error when the target key is not a map
 			preset:           true,
-			key:              "key6",
+			key:              "HsetKey6",
 			presetValue:      "Default preset value",
-			command:          []string{"HSET", "key6", "field1", "value1"},
+			command:          []string{"HSET", "HsetKey6", "field1", "value1"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key6 is not a hash"),
+			expectedError:    errors.New("value at HsetKey6 is not a hash"),
 		},
 		{ // HSET returns error when there's a mismatch in key/values
 			preset:           false,
-			key:              "key7",
+			key:              "HsetKey7",
 			presetValue:      nil,
-			command:          []string{"HSET", "key7", "field1", "value1", "field2"},
+			command:          []string{"HSET", "HsetKey7", "field1", "value1", "field2"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New("each field must have a corresponding value"),
 		},
 		{ // Command too short
 			preset:           true,
-			key:              "key8",
+			key:              "HsetKey8",
 			presetValue:      nil,
 			command:          []string{"HSET", "field1"},
 			expectedResponse: 0,
@@ -143,8 +152,6 @@ func Test_HandleHSET(t *testing.T) {
 
 func Test_HandleHINCRBY(t *testing.T) {
 	// Tests for both HINCRBY and HINCRBYFLOAT
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -156,90 +163,90 @@ func Test_HandleHINCRBY(t *testing.T) {
 	}{
 		{ // Increment by integer on non-existent hash should create a new one
 			preset:           false,
-			key:              "key1",
+			key:              "HincrbyKey1",
 			presetValue:      nil,
-			command:          []string{"HINCRBY", "key1", "field1", "1"},
+			command:          []string{"HINCRBY", "HincrbyKey1", "field1", "1"},
 			expectedResponse: 1,
 			expectedValue:    map[string]interface{}{"field1": 1},
 			expectedError:    nil,
 		},
 		{ // Increment by float on non-existent hash should create one
 			preset:           false,
-			key:              "key2",
+			key:              "HincrbyKey2",
 			presetValue:      nil,
-			command:          []string{"HINCRBYFLOAT", "key2", "field1", "3.142"},
+			command:          []string{"HINCRBYFLOAT", "HincrbyKey2", "field1", "3.142"},
 			expectedResponse: "3.142",
 			expectedValue:    map[string]interface{}{"field1": 3.142},
 			expectedError:    nil,
 		},
 		{ // Increment by integer on existing hash
 			preset:           true,
-			key:              "key3",
+			key:              "HincrbyKey3",
 			presetValue:      map[string]interface{}{"field1": 1},
-			command:          []string{"HINCRBY", "key3", "field1", "10"},
+			command:          []string{"HINCRBY", "HincrbyKey3", "field1", "10"},
 			expectedResponse: 11,
 			expectedValue:    map[string]interface{}{"field1": 11},
 			expectedError:    nil,
 		},
 		{ // Increment by float on an existing hash
 			preset:           true,
-			key:              "key4",
+			key:              "HincrbyKey4",
 			presetValue:      map[string]interface{}{"field1": 3.142},
-			command:          []string{"HINCRBYFLOAT", "key4", "field1", "3.142"},
+			command:          []string{"HINCRBYFLOAT", "HincrbyKey4", "field1", "3.142"},
 			expectedResponse: "6.284",
 			expectedValue:    map[string]interface{}{"field1": 6.284},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key5",
+			key:              "HincrbyKey5",
 			presetValue:      nil,
-			command:          []string{"HINCRBY", "key5"},
+			command:          []string{"HINCRBY", "HincrbyKey5"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key6",
+			key:              "HincrbyKey6",
 			presetValue:      nil,
-			command:          []string{"HINCRBY", "key6", "field1", "23", "45"},
+			command:          []string{"HINCRBY", "HincrbyKey6", "field1", "23", "45"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Error when increment by float does not pass valid float
 			preset:           false,
-			key:              "key7",
+			key:              "HincrbyKey7",
 			presetValue:      nil,
-			command:          []string{"HINCRBYFLOAT", "key7", "field1", "three point one four two"},
+			command:          []string{"HINCRBYFLOAT", "HincrbyKey7", "field1", "three point one four two"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New("increment must be a float"),
 		},
 		{ // Error when increment does not pass valid integer
 			preset:           false,
-			key:              "key8",
+			key:              "HincrbyKey8",
 			presetValue:      nil,
-			command:          []string{"HINCRBY", "key8", "field1", "three"},
+			command:          []string{"HINCRBY", "HincrbyKey8", "field1", "three"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New("increment must be an integer"),
 		},
 		{ // Error when trying to increment on a key that is not a hash
 			preset:           true,
-			key:              "key9",
+			key:              "HincrbyKey9",
 			presetValue:      "Default value",
-			command:          []string{"HINCRBY", "key9", "field1", "3"},
+			command:          []string{"HINCRBY", "HincrbyKey9", "field1", "3"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key9 is not a hash"),
+			expectedError:    errors.New("value at HincrbyKey9 is not a hash"),
 		},
 		{ // Error when trying to increment a hash field that is not a number
 			preset:           true,
-			key:              "key10",
+			key:              "HincrbyKey10",
 			presetValue:      map[string]interface{}{"field1": "value1"},
-			command:          []string{"HINCRBY", "key10", "field1", "3"},
+			command:          []string{"HINCRBY", "HincrbyKey10", "field1", "3"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New("value at field field1 is not a number"),
@@ -299,8 +306,6 @@ func Test_HandleHINCRBY(t *testing.T) {
 }
 
 func Test_HandleHGET(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -312,36 +317,36 @@ func Test_HandleHGET(t *testing.T) {
 	}{
 		{ // Return nil when attempting to get from non-existed key
 			preset:           true,
-			key:              "key1",
+			key:              "HgetKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 365, "field3": 3.142},
-			command:          []string{"HGET", "key1", "field1", "field2", "field3", "field4"},
+			command:          []string{"HGET", "HgetKey1", "field1", "field2", "field3", "field4"},
 			expectedResponse: []interface{}{"value1", 365, "3.142", nil},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Return nil when attempting to get from non-existed key
 			preset:           false,
-			key:              "key2",
+			key:              "HgetKey2",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HGET", "key2", "field1"},
+			command:          []string{"HGET", "HgetKey2", "field1"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Error when trying to get from a value that is not a hash map
 			preset:           true,
-			key:              "key3",
+			key:              "HgetKey3",
 			presetValue:      "Default Value",
-			command:          []string{"HGET", "key3", "field1"},
+			command:          []string{"HGET", "HgetKey3", "field1"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key3 is not a hash"),
+			expectedError:    errors.New("value at HgetKey3 is not a hash"),
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key4",
+			key:              "HgetKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HGET", "key4"},
+			command:          []string{"HGET", "HgetKey4"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
@@ -401,8 +406,6 @@ func Test_HandleHGET(t *testing.T) {
 }
 
 func Test_HandleHSTRLEN(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -416,39 +419,39 @@ func Test_HandleHSTRLEN(t *testing.T) {
 			// Return lengths of field values.
 			// If the key does not exist, its length should be 0.
 			preset:           true,
-			key:              "key1",
+			key:              "HstrlenKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HSTRLEN", "key1", "field1", "field2", "field3", "field4"},
+			command:          []string{"HSTRLEN", "HstrlenKey1", "field1", "field2", "field3", "field4"},
 			expectedResponse: []int{len("value1"), len("123456789"), len("3.142"), 0},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Nil response when trying to get HSTRLEN non-existent key
 			preset:           false,
-			key:              "key2",
+			key:              "HstrlenKey2",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HSTRLEN", "key2", "field1"},
+			command:          []string{"HSTRLEN", "HstrlenKey2", "field1"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "HstrlenKey3",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HSTRLEN", "key3"},
+			command:          []string{"HSTRLEN", "HstrlenKey3"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non hash map returns error
 			preset:           true,
-			key:              "key4",
+			key:              "HstrlenKey4",
 			presetValue:      "Default value",
-			command:          []string{"HSTRLEN", "key4", "field1"},
+			command:          []string{"HSTRLEN", "HstrlenKey4", "field1"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key4 is not a hash"),
+			expectedError:    errors.New("value at HstrlenKey4 is not a hash"),
 		},
 	}
 
@@ -492,8 +495,6 @@ func Test_HandleHSTRLEN(t *testing.T) {
 }
 
 func Test_HandleHVALS(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -506,25 +507,25 @@ func Test_HandleHVALS(t *testing.T) {
 		{
 			// Return all the values from a hash
 			preset:           true,
-			key:              "key1",
+			key:              "HvalsKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HVALS", "key1"},
+			command:          []string{"HVALS", "HvalsKey1"},
 			expectedResponse: []interface{}{"value1", 123456789, "3.142"},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Empty array response when trying to get HSTRLEN non-existent key
 			preset:           false,
-			key:              "key2",
+			key:              "HvalsKey2",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HVALS", "key2"},
+			command:          []string{"HVALS", "HvalsKey2"},
 			expectedResponse: []interface{}{},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "HvalsKey3",
 			presetValue:      map[string]interface{}{},
 			command:          []string{"HVALS"},
 			expectedResponse: nil,
@@ -533,21 +534,21 @@ func Test_HandleHVALS(t *testing.T) {
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "HvalsKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HVALS", "key4", "key4"},
+			command:          []string{"HVALS", "HvalsKey4", "HvalsKey4"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non hash map returns error
 			preset:           true,
-			key:              "key5",
+			key:              "HvalsKey5",
 			presetValue:      "Default value",
-			command:          []string{"HVALS", "key5"},
+			command:          []string{"HVALS", "HvalsKey5"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key5 is not a hash"),
+			expectedError:    errors.New("value at HvalsKey5 is not a hash"),
 		},
 	}
 
@@ -608,8 +609,6 @@ func Test_HandleHVALS(t *testing.T) {
 }
 
 func Test_HandleHRANDFIELD(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -622,9 +621,9 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 	}{
 		{ // Get a random field
 			preset:           true,
-			key:              "key1",
+			key:              "HrandfieldKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HRANDFIELD", "key1"},
+			command:          []string{"HRANDFIELD", "HrandfieldKey1"},
 			withValues:       false,
 			expectedCount:    1,
 			expectedResponse: []string{"field1", "field2", "field3"},
@@ -632,9 +631,9 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 		},
 		{ // Get a random field with a value
 			preset:           true,
-			key:              "key2",
+			key:              "HrandfieldKey2",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HRANDFIELD", "key2", "1", "WITHVALUES"},
+			command:          []string{"HRANDFIELD", "HrandfieldKey2", "1", "WITHVALUES"},
 			withValues:       true,
 			expectedCount:    2,
 			expectedResponse: []string{"field1", "value1", "field2", "123456789", "field3", "3.142"},
@@ -642,7 +641,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 		},
 		{ // Get several random fields
 			preset: true,
-			key:    "key3",
+			key:    "HrandfieldKey3",
 			presetValue: map[string]interface{}{
 				"field1": "value1",
 				"field2": 123456789,
@@ -650,7 +649,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 				"field4": "value4",
 				"field5": "value5",
 			},
-			command:          []string{"HRANDFIELD", "key3", "3"},
+			command:          []string{"HRANDFIELD", "HrandfieldKey3", "3"},
 			withValues:       false,
 			expectedCount:    3,
 			expectedResponse: []string{"field1", "field2", "field3", "field4", "field5"},
@@ -658,7 +657,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 		},
 		{ // Get several random fields with their corresponding values
 			preset: true,
-			key:    "key4",
+			key:    "HrandfieldKey4",
 			presetValue: map[string]interface{}{
 				"field1": "value1",
 				"field2": 123456789,
@@ -666,7 +665,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 				"field4": "value4",
 				"field5": "value5",
 			},
-			command:       []string{"HRANDFIELD", "key4", "3", "WITHVALUES"},
+			command:       []string{"HRANDFIELD", "HrandfieldKey4", "3", "WITHVALUES"},
 			withValues:    true,
 			expectedCount: 6,
 			expectedResponse: []string{
@@ -677,7 +676,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 		},
 		{ // Get the entire hash
 			preset: true,
-			key:    "key5",
+			key:    "HrandfieldKey5",
 			presetValue: map[string]interface{}{
 				"field1": "value1",
 				"field2": 123456789,
@@ -685,7 +684,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 				"field4": "value4",
 				"field5": "value5",
 			},
-			command:          []string{"HRANDFIELD", "key5", "5"},
+			command:          []string{"HRANDFIELD", "HrandfieldKey5", "5"},
 			withValues:       false,
 			expectedCount:    5,
 			expectedResponse: []string{"field1", "field2", "field3", "field4", "field5"},
@@ -693,7 +692,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 		},
 		{ // Get the entire hash with values
 			preset: true,
-			key:    "key5",
+			key:    "HrandfieldKey5",
 			presetValue: map[string]interface{}{
 				"field1": "value1",
 				"field2": 123456789,
@@ -701,7 +700,7 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 				"field4": "value4",
 				"field5": "value5",
 			},
-			command:       []string{"HRANDFIELD", "key5", "5", "WITHVALUES"},
+			command:       []string{"HRANDFIELD", "HrandfieldKey5", "5", "WITHVALUES"},
 			withValues:    true,
 			expectedCount: 10,
 			expectedResponse: []string{
@@ -712,37 +711,37 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 		},
 		{ // Command too short
 			preset:        false,
-			key:           "key10",
+			key:           "HrandfieldKey10",
 			presetValue:   map[string]interface{}{},
 			command:       []string{"HRANDFIELD"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:        false,
-			key:           "key11",
+			key:           "HrandfieldKey11",
 			presetValue:   map[string]interface{}{},
-			command:       []string{"HRANDFIELD", "key11", "key11", "key11", "key11"},
+			command:       []string{"HRANDFIELD", "HrandfieldKey11", "HrandfieldKey11", "HrandfieldKey11", "HrandfieldKey11"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get random field on a non hash map returns error
 			preset:        true,
-			key:           "key12",
+			key:           "HrandfieldKey12",
 			presetValue:   "Default value",
-			command:       []string{"HRANDFIELD", "key12"},
-			expectedError: errors.New("value at key12 is not a hash"),
+			command:       []string{"HRANDFIELD", "HrandfieldKey12"},
+			expectedError: errors.New("value at HrandfieldKey12 is not a hash"),
 		},
 		{ // Throw error when count provided is not an integer
 			preset:        true,
-			key:           "key12",
+			key:           "HrandfieldKey12",
 			presetValue:   "Default value",
-			command:       []string{"HRANDFIELD", "key12", "COUNT"},
+			command:       []string{"HRANDFIELD", "HrandfieldKey12", "COUNT"},
 			expectedError: errors.New("count must be an integer"),
 		},
 		{ // If fourth argument is provided, it must be "WITHVALUES"
 			preset:        true,
-			key:           "key12",
+			key:           "HrandfieldKey12",
 			presetValue:   "Default value",
-			command:       []string{"HRANDFIELD", "key12", "10", "FLAG"},
+			command:       []string{"HRANDFIELD", "HrandfieldKey12", "10", "FLAG"},
 			expectedError: errors.New("result modifier must be withvalues"),
 		},
 	}
@@ -806,8 +805,6 @@ func Test_HandleHRANDFIELD(t *testing.T) {
 }
 
 func Test_HandleHLEN(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -820,25 +817,25 @@ func Test_HandleHLEN(t *testing.T) {
 		{
 			// Return the correct length of the hash
 			preset:           true,
-			key:              "key1",
+			key:              "HlenKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HLEN", "key1"},
+			command:          []string{"HLEN", "HlenKey1"},
 			expectedResponse: 3,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // 0 response when trying to call HLEN on non-existent key
 			preset:           false,
-			key:              "key2",
+			key:              "HlenKey2",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HLEN", "key2"},
+			command:          []string{"HLEN", "HlenKey2"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "HlenKey3",
 			presetValue:      map[string]interface{}{},
 			command:          []string{"HLEN"},
 			expectedResponse: 0,
@@ -847,21 +844,21 @@ func Test_HandleHLEN(t *testing.T) {
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "HlenKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HLEN", "key4", "key4"},
+			command:          []string{"HLEN", "HlenKey4", "HlenKey4"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non hash map returns error
 			preset:           true,
-			key:              "key5",
+			key:              "HlenKey5",
 			presetValue:      "Default value",
-			command:          []string{"HLEN", "key5"},
+			command:          []string{"HLEN", "HlenKey5"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key5 is not a hash"),
+			expectedError:    errors.New("value at HlenKey5 is not a hash"),
 		},
 	}
 
@@ -900,8 +897,6 @@ func Test_HandleHLEN(t *testing.T) {
 }
 
 func Test_HandleHKeys(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -914,25 +909,25 @@ func Test_HandleHKeys(t *testing.T) {
 		{
 			// Return an array containing all the keys of the hash
 			preset:           true,
-			key:              "key1",
+			key:              "HkeysKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HKEYS", "key1"},
+			command:          []string{"HKEYS", "HkeysKey1"},
 			expectedResponse: []string{"field1", "field2", "field3"},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Empty array response when trying to call HKEYS on non-existent key
 			preset:           false,
-			key:              "key2",
+			key:              "HkeysKey2",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HKEYS", "key2"},
+			command:          []string{"HKEYS", "HkeysKey2"},
 			expectedResponse: []string{},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "HkeysKey3",
 			presetValue:      map[string]interface{}{},
 			command:          []string{"HKEYS"},
 			expectedResponse: nil,
@@ -941,21 +936,21 @@ func Test_HandleHKeys(t *testing.T) {
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "HkeysKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HKEYS", "key4", "key4"},
+			command:          []string{"HKEYS", "HkeysKey4", "HkeysKey4"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non hash map returns error
 			preset:           true,
-			key:              "key5",
+			key:              "HkeysKey5",
 			presetValue:      "Default value",
-			command:          []string{"HKEYS", "key5"},
+			command:          []string{"HKEYS", "HkeysKey5"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key5 is not a hash"),
+			expectedError:    errors.New("value at HkeysKey5 is not a hash"),
 		},
 	}
 
@@ -1001,8 +996,6 @@ func Test_HandleHKeys(t *testing.T) {
 }
 
 func Test_HandleHGETALL(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -1015,25 +1008,25 @@ func Test_HandleHGETALL(t *testing.T) {
 		{
 			// Return an array containing all the fields and values of the hash
 			preset:           true,
-			key:              "key1",
+			key:              "HGetAllKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HGETALL", "key1"},
+			command:          []string{"HGETALL", "HGetAllKey1"},
 			expectedResponse: []string{"field1", "value1", "field2", "123456789", "field3", "3.142"},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Empty array response when trying to call HGETALL on non-existent key
 			preset:           false,
-			key:              "key2",
+			key:              "HGetAllKey2",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HGETALL", "key2"},
+			command:          []string{"HGETALL", "HGetAllKey2"},
 			expectedResponse: []string{},
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "HGetAllKey3",
 			presetValue:      map[string]interface{}{},
 			command:          []string{"HGETALL"},
 			expectedResponse: nil,
@@ -1042,21 +1035,21 @@ func Test_HandleHGETALL(t *testing.T) {
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "HGetAllKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HGETALL", "key4", "key4"},
+			command:          []string{"HGETALL", "HGetAllKey4", "HGetAllKey4"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non hash map returns error
 			preset:           true,
-			key:              "key5",
+			key:              "HGetAllKey5",
 			presetValue:      "Default value",
-			command:          []string{"HGETALL", "key5"},
+			command:          []string{"HGETALL", "HGetAllKey5"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key5 is not a hash"),
+			expectedError:    errors.New("value at HGetAllKey5 is not a hash"),
 		},
 	}
 
@@ -1113,8 +1106,6 @@ func Test_HandleHGETALL(t *testing.T) {
 }
 
 func Test_HandleHEXISTS(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -1127,48 +1118,48 @@ func Test_HandleHEXISTS(t *testing.T) {
 		{
 			// Return 1 if the field exists in the hash
 			preset:           true,
-			key:              "key1",
+			key:              "HexistsKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142},
-			command:          []string{"HEXISTS", "key1", "field1"},
+			command:          []string{"HEXISTS", "HexistsKey1", "field1"},
 			expectedResponse: 1,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // 0 response when trying to call HEXISTS on non-existent key
 			preset:           false,
-			key:              "key2",
+			key:              "HexistsKey2",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HEXISTS", "key2", "field1"},
+			command:          []string{"HEXISTS", "HexistsKey2", "field1"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "HexistsKey3",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HEXISTS", "key3"},
+			command:          []string{"HEXISTS", "HexistsKey3"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "HexistsKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HEXISTS", "key4", "field1", "field2"},
+			command:          []string{"HEXISTS", "HexistsKey4", "field1", "field2"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non hash map returns error
 			preset:           true,
-			key:              "key5",
+			key:              "HexistsKey5",
 			presetValue:      "Default value",
-			command:          []string{"HEXISTS", "key5", "field1"},
+			command:          []string{"HEXISTS", "HexistsKey5", "field1"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key5 is not a hash"),
+			expectedError:    errors.New("value at HexistsKey5 is not a hash"),
 		},
 	}
 
@@ -1207,8 +1198,6 @@ func Test_HandleHEXISTS(t *testing.T) {
 }
 
 func Test_HandleHDEL(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -1221,48 +1210,48 @@ func Test_HandleHDEL(t *testing.T) {
 		{
 			// Return count of deleted fields in the specified hash
 			preset:           true,
-			key:              "key1",
+			key:              "HdelKey1",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": 123456789, "field3": 3.142, "field7": "value7"},
-			command:          []string{"HDEL", "key1", "field1", "field2", "field3", "field4", "field5", "field6"},
+			command:          []string{"HDEL", "HdelKey1", "field1", "field2", "field3", "field4", "field5", "field6"},
 			expectedResponse: 3,
 			expectedValue:    map[string]interface{}{"field1": nil, "field2": nil, "field3": nil, "field7": "value1"},
 			expectedError:    nil,
 		},
 		{ // 0 response when passing delete fields that are non-existent on valid hash
 			preset:           true,
-			key:              "key2",
+			key:              "HdelKey2",
 			presetValue:      map[string]interface{}{"field1": "value1", "field2": "value2", "field3": "value3"},
-			command:          []string{"HDEL", "key2", "field4", "field5", "field6"},
+			command:          []string{"HDEL", "HdelKey2", "field4", "field5", "field6"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{"field1": "value1", "field2": "value2", "field3": "value3"},
 			expectedError:    nil,
 		},
 		{ // 0 response when trying to call HDEL on non-existent key
 			preset:           false,
-			key:              "key3",
+			key:              "HdelKey3",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HDEL", "key3", "field1"},
+			command:          []string{"HDEL", "HdelKey3", "field1"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key4",
+			key:              "HdelKey4",
 			presetValue:      map[string]interface{}{},
-			command:          []string{"HDEL", "key4"},
+			command:          []string{"HDEL", "HdelKey4"},
 			expectedResponse: nil,
 			expectedValue:    map[string]interface{}{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non hash map returns error
 			preset:           true,
-			key:              "key5",
+			key:              "HdelKey5",
 			presetValue:      "Default value",
-			command:          []string{"HDEL", "key5", "field1"},
+			command:          []string{"HDEL", "HdelKey5", "field1"},
 			expectedResponse: 0,
 			expectedValue:    map[string]interface{}{},
-			expectedError:    errors.New("value at key5 is not a hash"),
+			expectedError:    errors.New("value at HdelKey5 is not a hash"),
 		},
 	}
 

--- a/src/modules/list/commands_test.go
+++ b/src/modules/list/commands_test.go
@@ -11,9 +11,18 @@ import (
 	"testing"
 )
 
-func Test_HandleLLEN(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
+var mockServer *server.Server
 
+func init() {
+	mockServer = server.NewServer(server.Opts{
+		Config: utils.Config{
+			DataDir:        "",
+			EvictionPolicy: utils.NoEviction,
+		},
+	})
+}
+
+func Test_HandleLLEN(t *testing.T) {
 	tests := []struct {
 		preset           bool
 		key              string
@@ -25,25 +34,25 @@ func Test_HandleLLEN(t *testing.T) {
 	}{
 		{ // If key exists and is a list, return the lists length
 			preset:           true,
-			key:              "key1",
+			key:              "LlenKey1",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LLEN", "key1"},
+			command:          []string{"LLEN", "LlenKey1"},
 			expectedResponse: 4,
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // If key does not exist, return 0
 			preset:           false,
-			key:              "key2",
+			key:              "LlenKey2",
 			presetValue:      nil,
-			command:          []string{"LLEN", "key2"},
+			command:          []string{"LLEN", "LlenKey2"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "LlenKey3",
 			presetValue:      nil,
 			command:          []string{"LLEN"},
 			expectedResponse: 0,
@@ -52,18 +61,18 @@ func Test_HandleLLEN(t *testing.T) {
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "LlenKey4",
 			presetValue:      nil,
-			command:          []string{"LLEN", "key4", "key4"},
+			command:          []string{"LLEN", "LlenKey4", "LlenKey4"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get lengths on a non-list returns error
 			preset:           true,
-			key:              "key5",
+			key:              "LlenKey5",
 			presetValue:      "Default value",
-			command:          []string{"LLEN", "key5"},
+			command:          []string{"LLEN", "LlenKey5"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LLEN command on non-list item"),
@@ -101,8 +110,6 @@ func Test_HandleLLEN(t *testing.T) {
 }
 
 func Test_HandleLINDEX(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -114,90 +121,90 @@ func Test_HandleLINDEX(t *testing.T) {
 	}{
 		{ // Return last element within range
 			preset:           true,
-			key:              "key1",
+			key:              "LindexKey1",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LINDEX", "key1", "3"},
+			command:          []string{"LINDEX", "LindexKey1", "3"},
 			expectedResponse: "value4",
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // Return first element within range
 			preset:           true,
-			key:              "key2",
+			key:              "LindexKey2",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LINDEX", "key1", "0"},
+			command:          []string{"LINDEX", "LindexKey1", "0"},
 			expectedResponse: "value1",
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // Return middle element within range
 			preset:           true,
-			key:              "key3",
+			key:              "LindexKey3",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LINDEX", "key1", "1"},
+			command:          []string{"LINDEX", "LindexKey1", "1"},
 			expectedResponse: "value2",
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // If key does not exist, return error
 			preset:           false,
-			key:              "key4",
+			key:              "LindexKey4",
 			presetValue:      nil,
-			command:          []string{"LINDEX", "key4", "0"},
+			command:          []string{"LINDEX", "LindexKey4", "0"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LINDEX command on non-list item"),
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "LindexKey3",
 			presetValue:      nil,
-			command:          []string{"LINDEX", "key3"},
+			command:          []string{"LINDEX", "LindexKey3"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "LindexKey4",
 			presetValue:      nil,
-			command:          []string{"LINDEX", "key4", "0", "20"},
+			command:          []string{"LINDEX", "LindexKey4", "0", "20"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get element by index on a non-list returns error
 			preset:           true,
-			key:              "key5",
+			key:              "LindexKey5",
 			presetValue:      "Default value",
-			command:          []string{"LINDEX", "key5", "0"},
+			command:          []string{"LINDEX", "LindexKey5", "0"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LINDEX command on non-list item"),
 		},
 		{ // Trying to get index out of range index beyond last index
 			preset:           true,
-			key:              "key6",
+			key:              "LindexKey6",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LINDEX", "key6", "3"},
+			command:          []string{"LINDEX", "LindexKey6", "3"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("index must be within list range"),
 		},
 		{ // Trying to get index out of range with negative index
 			preset:           true,
-			key:              "key7",
+			key:              "LindexKey7",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LINDEX", "key7", "-1"},
+			command:          []string{"LINDEX", "LindexKey7", "-1"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("index must be within list range"),
 		},
 		{ // Return error when index is not an integer
 			preset:           false,
-			key:              "key8",
+			key:              "LindexKey8",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LINDEX", "key8", "index"},
+			command:          []string{"LINDEX", "LindexKey8", "index"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("index must be an integer"),
@@ -235,8 +242,6 @@ func Test_HandleLINDEX(t *testing.T) {
 }
 
 func Test_HandleLRANGE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -251,108 +256,108 @@ func Test_HandleLRANGE(t *testing.T) {
 			// Both start and end indices are positive.
 			// End index is greater than start index.
 			preset:           true,
-			key:              "key1",
+			key:              "LrangeKey1",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8"},
-			command:          []string{"LRANGE", "key1", "3", "6"},
+			command:          []string{"LRANGE", "LrangeKey1", "3", "6"},
 			expectedResponse: []interface{}{"value4", "value5", "value6", "value7"},
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // Return sub-list from start index to the end of the list when end index is -1
 			preset:           true,
-			key:              "key2",
+			key:              "LrangeKey2",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8"},
-			command:          []string{"LRANGE", "key2", "3", "-1"},
+			command:          []string{"LRANGE", "LrangeKey2", "3", "-1"},
 			expectedResponse: []interface{}{"value4", "value5", "value6", "value7", "value8"},
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // Return the reversed sub-list when the end index is greater than -1 but less than start index
 			preset:           true,
-			key:              "key3",
+			key:              "LrangeKey3",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8"},
-			command:          []string{"LRANGE", "key3", "3", "0"},
+			command:          []string{"LRANGE", "LrangeKey3", "3", "0"},
 			expectedResponse: []interface{}{"value4", "value3", "value2", "value1"},
 			expectedValue:    nil,
 			expectedError:    nil,
 		},
 		{ // If key does not exist, return error
 			preset:           false,
-			key:              "key4",
+			key:              "LrangeKey4",
 			presetValue:      nil,
-			command:          []string{"LRANGE", "key4", "0", "2"},
+			command:          []string{"LRANGE", "LrangeKey4", "0", "2"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("LRANGE command on non-list item"),
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key5",
+			key:              "LrangeKey5",
 			presetValue:      nil,
-			command:          []string{"LRANGE", "key5"},
+			command:          []string{"LRANGE", "LrangeKey5"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key6",
+			key:              "LrangeKey6",
 			presetValue:      nil,
-			command:          []string{"LRANGE", "key6", "0", "element", "element"},
+			command:          []string{"LRANGE", "LrangeKey6", "0", "element", "element"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Error when executing command on non-list command
 			preset:           true,
-			key:              "key5",
+			key:              "LrangeKey5",
 			presetValue:      "Default value",
-			command:          []string{"LRANGE", "key5", "0", "3"},
+			command:          []string{"LRANGE", "LrangeKey5", "0", "3"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("LRANGE command on non-list item"),
 		},
 		{ // Error when start index is less than 0
 			preset:           true,
-			key:              "key7",
+			key:              "LrangeKey7",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LRANGE", "key7", "-1", "3"},
+			command:          []string{"LRANGE", "LrangeKey7", "-1", "3"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("start index must be within list boundary"),
 		},
 		{ // Error when start index is higher than the length of the list
 			preset:           true,
-			key:              "key8",
+			key:              "LrangeKey8",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LRANGE", "key8", "10", "11"},
+			command:          []string{"LRANGE", "LrangeKey8", "10", "11"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("start index must be within list boundary"),
 		},
 		{ // Return error when start index is not an integer
 			preset:           false,
-			key:              "key9",
+			key:              "LrangeKey9",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LRANGE", "key9", "start", "7"},
+			command:          []string{"LRANGE", "LrangeKey9", "start", "7"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("start and end indices must be integers"),
 		},
 		{ // Return error when end index is not an integer
 			preset:           false,
-			key:              "key10",
+			key:              "LrangeKey10",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LRANGE", "key10", "0", "end"},
+			command:          []string{"LRANGE", "LrangeKey10", "0", "end"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("start and end indices must be integers"),
 		},
 		{ // Error when start and end indices are equal
 			preset:           true,
-			key:              "key11",
+			key:              "LrangeKey11",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LRANGE", "key11", "1", "1"},
+			command:          []string{"LRANGE", "LrangeKey11", "1", "1"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("start and end indices cannot be equal"),
@@ -396,8 +401,6 @@ func Test_HandleLRANGE(t *testing.T) {
 }
 
 func Test_HandleLSET(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -409,90 +412,90 @@ func Test_HandleLSET(t *testing.T) {
 	}{
 		{ // Return last element within range
 			preset:           true,
-			key:              "key1",
+			key:              "LsetKey1",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LSET", "key1", "3", "new-value"},
+			command:          []string{"LSET", "LsetKey1", "3", "new-value"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value1", "value2", "value3", "new-value"},
 			expectedError:    nil,
 		},
 		{ // Return first element within range
 			preset:           true,
-			key:              "key2",
+			key:              "LsetKey2",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LSET", "key2", "0", "new-value"},
+			command:          []string{"LSET", "LsetKey2", "0", "new-value"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"new-value", "value2", "value3", "value4"},
 			expectedError:    nil,
 		},
 		{ // Return middle element within range
 			preset:           true,
-			key:              "key3",
+			key:              "LsetKey3",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LSET", "key3", "1", "new-value"},
+			command:          []string{"LSET", "LsetKey3", "1", "new-value"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value1", "new-value", "value3", "value4"},
 			expectedError:    nil,
 		},
 		{ // If key does not exist, return error
 			preset:           false,
-			key:              "key4",
+			key:              "LsetKey4",
 			presetValue:      nil,
-			command:          []string{"LSET", "key4", "0", "element"},
+			command:          []string{"LSET", "LsetKey4", "0", "element"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LSET command on non-list item"),
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key5",
+			key:              "LsetKey5",
 			presetValue:      nil,
-			command:          []string{"LSET", "key5"},
+			command:          []string{"LSET", "LsetKey5"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key6",
+			key:              "LsetKey6",
 			presetValue:      nil,
-			command:          []string{"LSET", "key6", "0", "element", "element"},
+			command:          []string{"LSET", "LsetKey6", "0", "element", "element"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get element by index on a non-list returns error
 			preset:           true,
-			key:              "key5",
+			key:              "LsetKey5",
 			presetValue:      "Default value",
-			command:          []string{"LSET", "key5", "0", "element"},
+			command:          []string{"LSET", "LsetKey5", "0", "element"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LSET command on non-list item"),
 		},
 		{ // Trying to get index out of range index beyond last index
 			preset:           true,
-			key:              "key6",
+			key:              "LsetKey6",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LSET", "key6", "3", "element"},
+			command:          []string{"LSET", "LsetKey6", "3", "element"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("index must be within list range"),
 		},
 		{ // Trying to get index out of range with negative index
 			preset:           true,
-			key:              "key7",
+			key:              "LsetKey7",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LSET", "key7", "-1", "element"},
+			command:          []string{"LSET", "LsetKey7", "-1", "element"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("index must be within list range"),
 		},
 		{ // Return error when index is not an integer
 			preset:           false,
-			key:              "key8",
+			key:              "LsetKey8",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LSET", "key8", "index", "element"},
+			command:          []string{"LSET", "LsetKey8", "index", "element"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("index must be an integer"),
@@ -546,8 +549,6 @@ func Test_HandleLSET(t *testing.T) {
 }
 
 func Test_HandleLTRIM(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -562,99 +563,99 @@ func Test_HandleLTRIM(t *testing.T) {
 			// Both start and end indices are positive.
 			// End index is greater than start index.
 			preset:           true,
-			key:              "key1",
+			key:              "LtrimKey1",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8"},
-			command:          []string{"LTRIM", "key1", "3", "6"},
+			command:          []string{"LTRIM", "LtrimKey1", "3", "6"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value4", "value5", "value6"},
 			expectedError:    nil,
 		},
 		{ // Return element from start index to end index when end index is greater than length of the list
 			preset:           true,
-			key:              "key2",
+			key:              "LtrimKey2",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8"},
-			command:          []string{"LTRIM", "key2", "5", "-1"},
+			command:          []string{"LTRIM", "LtrimKey2", "5", "-1"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value6", "value7", "value8"},
 			expectedError:    nil,
 		},
 		{ // Return error when end index is smaller than start index but greater than -1
 			preset:           true,
-			key:              "key3",
+			key:              "LtrimKey3",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LTRIM", "key3", "3", "1"},
+			command:          []string{"LTRIM", "LtrimKey3", "3", "1"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("end index must be greater than start index or -1"),
 		},
 		{ // If key does not exist, return error
 			preset:           false,
-			key:              "key4",
+			key:              "LtrimKey4",
 			presetValue:      nil,
-			command:          []string{"LTRIM", "key4", "0", "2"},
+			command:          []string{"LTRIM", "LtrimKey4", "0", "2"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LTRIM command on non-list item"),
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key5",
+			key:              "LtrimKey5",
 			presetValue:      nil,
-			command:          []string{"LTRIM", "key5"},
+			command:          []string{"LTRIM", "LtrimKey5"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key6",
+			key:              "LtrimKey6",
 			presetValue:      nil,
-			command:          []string{"LTRIM", "key6", "0", "element", "element"},
+			command:          []string{"LTRIM", "LtrimKey6", "0", "element", "element"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to get element by index on a non-list returns error
 			preset:           true,
-			key:              "key5",
+			key:              "LtrimKey5",
 			presetValue:      "Default value",
-			command:          []string{"LTRIM", "key5", "0", "3"},
+			command:          []string{"LTRIM", "LtrimKey5", "0", "3"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LTRIM command on non-list item"),
 		},
 		{ // Error when start index is less than 0
 			preset:           true,
-			key:              "key7",
+			key:              "LtrimKey7",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LTRIM", "key7", "-1", "3"},
+			command:          []string{"LTRIM", "LtrimKey7", "-1", "3"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("start index must be within list boundary"),
 		},
 		{ // Error when start index is higher than the length of the list
 			preset:           true,
-			key:              "key8",
+			key:              "LtrimKey8",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LTRIM", "key8", "10", "11"},
+			command:          []string{"LTRIM", "LtrimKey8", "10", "11"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("start index must be within list boundary"),
 		},
 		{ // Return error when start index is not an integer
 			preset:           false,
-			key:              "key9",
+			key:              "LtrimKey9",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LTRIM", "key9", "start", "7"},
+			command:          []string{"LTRIM", "LtrimKey9", "start", "7"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("start and end indices must be integers"),
 		},
 		{ // Return error when end index is not an integer
 			preset:           false,
-			key:              "key10",
+			key:              "LtrimKey10",
 			presetValue:      []interface{}{"value1", "value2", "value3"},
-			command:          []string{"LTRIM", "key10", "0", "end"},
+			command:          []string{"LTRIM", "LtrimKey10", "0", "end"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("start and end indices must be integers"),
@@ -708,8 +709,6 @@ func Test_HandleLTRIM(t *testing.T) {
 }
 
 func Test_HandleLREM(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -721,63 +720,63 @@ func Test_HandleLREM(t *testing.T) {
 	}{
 		{ // Remove the first 3 elements that appear in the list
 			preset:           true,
-			key:              "key1",
+			key:              "LremKey1",
 			presetValue:      []interface{}{"1", "2", "4", "4", "5", "6", "7", "4", "8", "4", "9", "10", "5", "4"},
-			command:          []string{"LREM", "key1", "3", "4"},
+			command:          []string{"LREM", "LremKey1", "3", "4"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"1", "2", "5", "6", "7", "8", "4", "9", "10", "5", "4"},
 			expectedError:    nil,
 		},
 		{ // Remove the last 3 elements that appear in the list
 			preset:           true,
-			key:              "key1",
+			key:              "LremKey1",
 			presetValue:      []interface{}{"1", "2", "4", "4", "5", "6", "7", "4", "8", "4", "9", "10", "5", "4"},
-			command:          []string{"LREM", "key1", "-3", "4"},
+			command:          []string{"LREM", "LremKey1", "-3", "4"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"1", "2", "4", "4", "5", "6", "7", "8", "9", "10", "5"},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key5",
+			key:              "LremKey5",
 			presetValue:      nil,
-			command:          []string{"LREM", "key5"},
+			command:          []string{"LREM", "LremKey5"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key6",
+			key:              "LremKey6",
 			presetValue:      nil,
-			command:          []string{"LREM", "key6", "0", "element", "element"},
+			command:          []string{"LREM", "LremKey6", "0", "element", "element"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Throw error when count is not an integer
 			preset:           false,
-			key:              "key7",
+			key:              "LremKey7",
 			presetValue:      nil,
-			command:          []string{"LREM", "key7", "count", "value1"},
+			command:          []string{"LREM", "LremKey7", "count", "value1"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("count must be an integer"),
 		},
 		{ // Throw error on non-list item
 			preset:           true,
-			key:              "key8",
+			key:              "LremKey8",
 			presetValue:      "Default value",
-			command:          []string{"LREM", "key8", "0", "value1"},
+			command:          []string{"LREM", "LremKey8", "0", "value1"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("LREM command on non-list item"),
 		},
 		{ // Throw error on non-existent item
 			preset:           false,
-			key:              "key9",
+			key:              "LremKey9",
 			presetValue:      "Default value",
-			command:          []string{"LREM", "key9", "0", "value1"},
+			command:          []string{"LREM", "LremKey9", "0", "value1"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("LREM command on non-list item"),
@@ -831,8 +830,6 @@ func Test_HandleLREM(t *testing.T) {
 }
 
 func Test_HandleLMOVE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValue      map[string]interface{}
@@ -1050,8 +1047,6 @@ func Test_HandleLMOVE(t *testing.T) {
 }
 
 func Test_HandleLPUSH(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -1063,45 +1058,45 @@ func Test_HandleLPUSH(t *testing.T) {
 	}{
 		{ // LPUSHX to existing list prepends the element to the list
 			preset:           true,
-			key:              "key1",
+			key:              "LpushKey1",
 			presetValue:      []interface{}{"1", "2", "4", "5"},
-			command:          []string{"LPUSHX", "key1", "value1", "value2"},
+			command:          []string{"LPUSHX", "LpushKey1", "value1", "value2"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value1", "value2", "1", "2", "4", "5"},
 			expectedError:    nil,
 		},
 		{ // LPUSH on existing list prepends the elements to the list
 			preset:           true,
-			key:              "key2",
+			key:              "LpushKey2",
 			presetValue:      []interface{}{"1", "2", "4", "5"},
-			command:          []string{"LPUSH", "key2", "value1", "value2"},
+			command:          []string{"LPUSH", "LpushKey2", "value1", "value2"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value1", "value2", "1", "2", "4", "5"},
 			expectedError:    nil,
 		},
 		{ // LPUSH on non-existent list creates the list
 			preset:           false,
-			key:              "key3",
+			key:              "LpushKey3",
 			presetValue:      nil,
-			command:          []string{"LPUSH", "key3", "value1", "value2"},
+			command:          []string{"LPUSH", "LpushKey3", "value1", "value2"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value1", "value2"},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key5",
+			key:              "LpushKey5",
 			presetValue:      nil,
-			command:          []string{"LPUSH", "key5"},
+			command:          []string{"LPUSH", "LpushKey5"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // LPUSHX command returns error on non-existent list
 			preset:           false,
-			key:              "key6",
+			key:              "LpushKey6",
 			presetValue:      nil,
-			command:          []string{"LPUSHX", "key7", "count", "value1"},
+			command:          []string{"LPUSHX", "LpushKey7", "count", "value1"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("LPUSHX command on non-list item"),
@@ -1155,8 +1150,6 @@ func Test_HandleLPUSH(t *testing.T) {
 }
 
 func Test_HandleRPUSH(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -1168,45 +1161,45 @@ func Test_HandleRPUSH(t *testing.T) {
 	}{
 		{ // RPUSHX to existing list prepends the element to the list
 			preset:           true,
-			key:              "key1",
+			key:              "RpushKey1",
 			presetValue:      []interface{}{"1", "2", "4", "5"},
-			command:          []string{"RPUSHX", "key1", "value1", "value2"},
+			command:          []string{"RPUSHX", "RpushKey1", "value1", "value2"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"1", "2", "4", "5", "value1", "value2"},
 			expectedError:    nil,
 		},
 		{ // RPUSH on existing list prepends the elements to the list
 			preset:           true,
-			key:              "key2",
+			key:              "RpushKey2",
 			presetValue:      []interface{}{"1", "2", "4", "5"},
-			command:          []string{"RPUSH", "key2", "value1", "value2"},
+			command:          []string{"RPUSH", "RpushKey2", "value1", "value2"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"1", "2", "4", "5", "value1", "value2"},
 			expectedError:    nil,
 		},
 		{ // RPUSH on non-existent list creates the list
 			preset:           false,
-			key:              "key3",
+			key:              "RpushKey3",
 			presetValue:      nil,
-			command:          []string{"RPUSH", "key3", "value1", "value2"},
+			command:          []string{"RPUSH", "RpushKey3", "value1", "value2"},
 			expectedResponse: "OK",
 			expectedValue:    []interface{}{"value1", "value2"},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key5",
+			key:              "RpushKey5",
 			presetValue:      nil,
-			command:          []string{"RPUSH", "key5"},
+			command:          []string{"RPUSH", "RpushKey5"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // RPUSHX command returns error on non-existent list
 			preset:           false,
-			key:              "key6",
+			key:              "RpushKey6",
 			presetValue:      nil,
-			command:          []string{"RPUSHX", "key7", "count", "value1"},
+			command:          []string{"RPUSHX", "RpushKey7", "count", "value1"},
 			expectedResponse: nil,
 			expectedValue:    nil,
 			expectedError:    errors.New("RPUSHX command on non-list item"),
@@ -1260,8 +1253,6 @@ func Test_HandleRPUSH(t *testing.T) {
 }
 
 func Test_HandlePop(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -1273,25 +1264,25 @@ func Test_HandlePop(t *testing.T) {
 	}{
 		{ // LPOP returns last element and removed first element from the list
 			preset:           true,
-			key:              "key1",
+			key:              "PopKey1",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"LPOP", "key1"},
+			command:          []string{"LPOP", "PopKey1"},
 			expectedResponse: "value1",
 			expectedValue:    []interface{}{"value2", "value3", "value4"},
 			expectedError:    nil,
 		},
 		{ // RPOP returns last element and removed last element from the list
 			preset:           true,
-			key:              "key2",
+			key:              "PopKey2",
 			presetValue:      []interface{}{"value1", "value2", "value3", "value4"},
-			command:          []string{"RPOP", "key2"},
+			command:          []string{"RPOP", "PopKey2"},
 			expectedResponse: "value4",
 			expectedValue:    []interface{}{"value1", "value2", "value3"},
 			expectedError:    nil,
 		},
 		{ // Command too short
 			preset:           false,
-			key:              "key3",
+			key:              "PopKey3",
 			presetValue:      nil,
 			command:          []string{"LPOP"},
 			expectedResponse: 0,
@@ -1300,27 +1291,27 @@ func Test_HandlePop(t *testing.T) {
 		},
 		{ // Command too long
 			preset:           false,
-			key:              "key4",
+			key:              "PopKey4",
 			presetValue:      nil,
-			command:          []string{"LPOP", "key4", "key4"},
+			command:          []string{"LPOP", "PopKey4", "PopKey4"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // Trying to execute LPOP from a non-list item return an error
 			preset:           true,
-			key:              "key5",
+			key:              "PopKey5",
 			presetValue:      "Default value",
-			command:          []string{"LPOP", "key5"},
+			command:          []string{"LPOP", "PopKey5"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("LPOP command on non-list item"),
 		},
 		{ // Trying to execute RPOP from a non-list item return an error
 			preset:           true,
-			key:              "key6",
+			key:              "PopKey6",
 			presetValue:      "Default value",
-			command:          []string{"RPOP", "key6"},
+			command:          []string{"RPOP", "PopKey6"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    errors.New("RPOP command on non-list item"),

--- a/src/modules/pubsub/channel.go
+++ b/src/modules/pubsub/channel.go
@@ -99,9 +99,13 @@ func (ch *Channel) Publish(message string) {
 }
 
 func (ch *Channel) IsActive() bool {
+	ch.subscribersRWMut.RLock()
+	defer ch.subscribersRWMut.RUnlock()
 	return len(ch.subscribers) > 0
 }
 
 func (ch *Channel) NumSubs() int {
+	ch.subscribersRWMut.RLock()
+	defer ch.subscribersRWMut.RUnlock()
 	return len(ch.subscribers)
 }

--- a/src/modules/pubsub/commands.go
+++ b/src/modules/pubsub/commands.go
@@ -49,7 +49,6 @@ func handlePublish(ctx context.Context, cmd []string, server utils.Server, conn 
 		return nil, errors.New(utils.WrongArgsResponse)
 	}
 	pubsub.Publish(ctx, cmd[2], cmd[1])
-	fmt.Println("PUBLISHED:", cmd[2])
 	return []byte(utils.OkResponse), nil
 }
 

--- a/src/modules/pubsub/commands.go
+++ b/src/modules/pubsub/commands.go
@@ -22,8 +22,9 @@ func handleSubscribe(ctx context.Context, cmd []string, server utils.Server, con
 	}
 
 	withPattern := strings.EqualFold(cmd[0], "psubscribe")
+	pubsub.Subscribe(ctx, conn, channels, withPattern)
 
-	return pubsub.Subscribe(ctx, conn, channels, withPattern), nil
+	return nil, nil
 }
 
 func handleUnsubscribe(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
@@ -48,6 +49,7 @@ func handlePublish(ctx context.Context, cmd []string, server utils.Server, conn 
 		return nil, errors.New(utils.WrongArgsResponse)
 	}
 	pubsub.Publish(ctx, cmd[2], cmd[1])
+	fmt.Println("PUBLISHED:", cmd[2])
 	return []byte(utils.OkResponse), nil
 }
 

--- a/src/modules/pubsub/commands.go
+++ b/src/modules/pubsub/commands.go
@@ -40,7 +40,7 @@ func handleUnsubscribe(ctx context.Context, cmd []string, server utils.Server, c
 	return pubsub.Unsubscribe(ctx, conn, channels, withPattern), nil
 }
 
-func handlePublish(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
+func handlePublish(ctx context.Context, cmd []string, server utils.Server, _ *net.Conn) ([]byte, error) {
 	pubsub, ok := server.GetPubSub().(*PubSub)
 	if !ok {
 		return nil, errors.New("could not load pubsub module")
@@ -52,7 +52,7 @@ func handlePublish(ctx context.Context, cmd []string, server utils.Server, conn 
 	return []byte(utils.OkResponse), nil
 }
 
-func handlePubSubChannels(_ context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
+func handlePubSubChannels(_ context.Context, cmd []string, server utils.Server, _ *net.Conn) ([]byte, error) {
 	if len(cmd) > 3 {
 		return nil, errors.New(utils.WrongArgsResponse)
 	}
@@ -70,7 +70,7 @@ func handlePubSubChannels(_ context.Context, cmd []string, server utils.Server, 
 	return pubsub.Channels(pattern), nil
 }
 
-func handlePubSubNumPat(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
+func handlePubSubNumPat(_ context.Context, _ []string, server utils.Server, _ *net.Conn) ([]byte, error) {
 	pubsub, ok := server.GetPubSub().(*PubSub)
 	if !ok {
 		return nil, errors.New("could not load pubsub module")
@@ -79,7 +79,7 @@ func handlePubSubNumPat(ctx context.Context, cmd []string, server utils.Server, 
 	return []byte(fmt.Sprintf(":%d\r\n", num)), nil
 }
 
-func handlePubSubNumSubs(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
+func handlePubSubNumSubs(_ context.Context, cmd []string, server utils.Server, _ *net.Conn) ([]byte, error) {
 	pubsub, ok := server.GetPubSub().(*PubSub)
 	if !ok {
 		return nil, errors.New("could not load pubsub module")

--- a/src/modules/pubsub/commands.go
+++ b/src/modules/pubsub/commands.go
@@ -75,7 +75,7 @@ func handlePubSubNumPat(ctx context.Context, cmd []string, server utils.Server, 
 	if !ok {
 		return nil, errors.New("could not load pubsub module")
 	}
-	num := pubsub.NumPat(ctx)
+	num := pubsub.NumPat()
 	return []byte(fmt.Sprintf(":%d\r\n", num)), nil
 }
 
@@ -84,7 +84,7 @@ func handlePubSubNumSubs(ctx context.Context, cmd []string, server utils.Server,
 	if !ok {
 		return nil, errors.New("could not load pubsub module")
 	}
-	return pubsub.NumSub(ctx, cmd[2:]), nil
+	return pubsub.NumSub(cmd[2:]), nil
 }
 
 func Commands() []utils.Command {

--- a/src/modules/pubsub/commands.go
+++ b/src/modules/pubsub/commands.go
@@ -21,14 +21,9 @@ func handleSubscribe(ctx context.Context, cmd []string, server utils.Server, con
 		return nil, errors.New(utils.WrongArgsResponse)
 	}
 
-	switch strings.ToLower(cmd[0]) {
-	case "subscribe":
-		return pubsub.Subscribe(ctx, conn, channels, false), nil
-	case "psubscribe":
-		return pubsub.Subscribe(ctx, conn, channels, true), nil
-	}
+	withPattern := strings.EqualFold(cmd[0], "psubscribe")
 
-	return []byte{}, nil
+	return pubsub.Subscribe(ctx, conn, channels, withPattern), nil
 }
 
 func handleUnsubscribe(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
@@ -39,14 +34,9 @@ func handleUnsubscribe(ctx context.Context, cmd []string, server utils.Server, c
 
 	channels := cmd[1:]
 
-	switch strings.ToLower(cmd[0]) {
-	case "unsubscribe":
-		return pubsub.Unsubscribe(ctx, conn, channels, false), nil
-	case "punsubscribe":
-		return pubsub.Unsubscribe(ctx, conn, channels, true), nil
-	default:
-		return []byte{}, nil
-	}
+	withPattern := strings.EqualFold(cmd[0], "punsubscribe")
+
+	return pubsub.Unsubscribe(ctx, conn, channels, withPattern), nil
 }
 
 func handlePublish(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
@@ -156,7 +146,7 @@ it's currently subscribe to.`,
 		{
 			Command:    "punsubscribe",
 			Categories: []string{utils.PubSubCategory, utils.ConnectionCategory, utils.SlowCategory},
-			Description: `(PUNSUBSCRIBE [channel [channel ...]]) Unsubscribe from a list of channels using patterns.
+			Description: `(PUNSUBSCRIBE [pattern [pattern ...]]) Unsubscribe from a list of channels using patterns.
 If the pattern list is not provided, then the connection will be unsubscribed from all the patterns that
 it's currently subscribe to.`,
 			Sync: false,

--- a/src/modules/pubsub/commands.go
+++ b/src/modules/pubsub/commands.go
@@ -53,7 +53,7 @@ func handlePublish(ctx context.Context, cmd []string, server utils.Server, conn 
 	return []byte(utils.OkResponse), nil
 }
 
-func handlePubSubChannels(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
+func handlePubSubChannels(_ context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {
 	if len(cmd) > 3 {
 		return nil, errors.New(utils.WrongArgsResponse)
 	}
@@ -68,7 +68,7 @@ func handlePubSubChannels(ctx context.Context, cmd []string, server utils.Server
 		pattern = cmd[2]
 	}
 
-	return pubsub.Channels(ctx, pattern), nil
+	return pubsub.Channels(pattern), nil
 }
 
 func handlePubSubNumPat(ctx context.Context, cmd []string, server utils.Server, conn *net.Conn) ([]byte, error) {

--- a/src/modules/pubsub/commands_test.go
+++ b/src/modules/pubsub/commands_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"slices"
 	"testing"
+	"time"
 )
 
 var pubsub *PubSub
@@ -21,7 +22,8 @@ var port uint16 = 7490
 func init() {
 	pubsub = NewPubSub()
 	mockServer = server.NewServer(server.Opts{
-		PubSub: pubsub,
+		PubSub:   pubsub,
+		Commands: Commands(),
 		Config: utils.Config{
 			BindAddr:       bindAddr,
 			Port:           port,
@@ -37,7 +39,7 @@ func init() {
 func Test_HandleSubscribe(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "test_name", "SUBSCRIBE/PSUBSCRIBE")
 
-	numOfConnection := 100
+	numOfConnection := 20
 	connections := make([]*net.Conn, numOfConnection)
 
 	for i := 0; i < numOfConnection; i++ {
@@ -47,6 +49,13 @@ func Test_HandleSubscribe(t *testing.T) {
 		}
 		connections[i] = &conn
 	}
+	defer func() {
+		for _, conn := range connections {
+			if err := (*conn).Close(); err != nil {
+				t.Error(err)
+			}
+		}
+	}()
 
 	// Test subscribe to channels
 	channels := []string{"sub_channel1", "sub_channel2", "sub_channel3"}
@@ -70,7 +79,7 @@ func Test_HandleSubscribe(t *testing.T) {
 				}
 				// Check if the channel has all the connections from above
 				for _, conn := range connections {
-					if !slices.Contains(c.subscribers, conn) {
+					if _, ok := c.subscribers[conn]; !ok {
 						t.Errorf("could not find all expected connection in the \"%s\"", channel)
 					}
 				}
@@ -100,7 +109,7 @@ func Test_HandleSubscribe(t *testing.T) {
 				}
 				// Check if the channel has all the connections from above
 				for _, conn := range connections {
-					if !slices.Contains(c.subscribers, conn) {
+					if _, ok := c.subscribers[conn]; !ok {
 						t.Errorf("could not find all expected connection in the \"%s\"", pattern)
 					}
 				}
@@ -122,6 +131,14 @@ func Test_HandleUnsubscribe(t *testing.T) {
 		return connections
 	}
 
+	closeConnections := func(conns []*net.Conn) {
+		for _, conn := range conns {
+			if err := (*conn).Close(); err != nil {
+				t.Error(err)
+			}
+		}
+	}
+
 	verifyResponse := func(res []byte, expectedResponse [][]string) {
 		rd := resp.NewReader(bytes.NewReader(res))
 		rv, _, err := rd.ReadValue()
@@ -130,6 +147,7 @@ func Test_HandleUnsubscribe(t *testing.T) {
 		}
 		v := rv.Array()
 		if len(v) != len(expectedResponse) {
+			fmt.Println(v)
 			t.Errorf("expected subscribe response of length %d, but got %d", len(expectedResponse), len(v))
 		}
 		for _, item := range v {
@@ -247,11 +265,11 @@ func Test_HandleUnsubscribe(t *testing.T) {
 			for _, pubsubChannel := range pubsub.channels {
 				if pubsubChannel.name == channel {
 					// Assert that target connection is no longer in the unsub channels and patterns
-					if slices.Contains(pubsubChannel.subscribers, test.targetConn) {
+					if _, ok := pubsubChannel.subscribers[test.targetConn]; ok {
 						t.Errorf("found unexpected target connection after unsubscrining in channel \"%s\"", channel)
 					}
 					for _, conn := range test.otherConnections {
-						if !slices.Contains(pubsubChannel.subscribers, conn) {
+						if _, ok := pubsubChannel.subscribers[conn]; !ok {
 							t.Errorf("did not find expected other connection in channel \"%s\"", channel)
 						}
 					}
@@ -263,16 +281,198 @@ func Test_HandleUnsubscribe(t *testing.T) {
 		for _, channel := range append(test.remainChannels, test.remainPatterns...) {
 			for _, pubsubChannel := range pubsub.channels {
 				if pubsubChannel.name == channel {
-					if !slices.Contains(pubsubChannel.subscribers, test.targetConn) {
-						t.Errorf("cound not find expected target connection in channel \"%s\"", channel)
+					if _, ok := pubsubChannel.subscribers[test.targetConn]; !ok {
+						t.Errorf("could not find expected target connection in channel \"%s\"", channel)
 					}
 				}
 			}
 		}
 	}
+
+	for _, test := range tests {
+		// Close all the connections
+		closeConnections(append(test.otherConnections, test.targetConn))
+	}
 }
 
-func Test_HandlePublish(t *testing.T) {}
+func Test_HandlePublish(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "test_name", "PUBLISH")
+
+	// verifyChannelMessage reads the message from the connection and asserts whether
+	// it's the message we expect to read as a subscriber of a channel or pattern.
+	verifyEvent := func(c *net.Conn, r *resp.Conn, expected []string) {
+		if err := (*c).SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+			t.Error(err)
+		}
+		rv, _, err := r.ReadValue()
+		if err != nil {
+			t.Error(err)
+		}
+		v := rv.Array()
+		for i := 0; i < len(v); i++ {
+			if v[i].String() != expected[i] {
+				t.Errorf("expected item at index %d to be \"%s\", got \"%s\"", i, expected[i], v[i].String())
+			}
+		}
+		fmt.Println(v)
+	}
+
+	// The subscribe function handles subscribing the connection to the given
+	// channels and patterns and reading/verifying the message sent by the server after
+	// subscription.
+	subscribe := func(ctx context.Context, channels []string, patterns []string, c *net.Conn, r *resp.Conn) {
+		// Subscribe to channels
+		go func() {
+			_, _ = handleSubscribe(ctx, append([]string{"SUBSCRIBE"}, channels...), mockServer, c)
+		}()
+		// Verify all the responses for each channel subscription
+		for i := 0; i < len(channels); i++ {
+			verifyEvent(c, r, []string{"subscribe", channels[i], fmt.Sprintf("%d", i+1)})
+		}
+		// Subscribe to all the patterns
+		go func() {
+			_, _ = handleSubscribe(ctx, append([]string{"PSUBSCRIBE"}, patterns...), mockServer, c)
+		}()
+		// Verify all the responses for each pattern subscription
+		for i := 0; i < len(patterns); i++ {
+			verifyEvent(c, r, []string{"subscribe", patterns[i], fmt.Sprintf("%d", i+1)})
+		}
+	}
+
+	subscriptions := map[string]map[string][]string{
+		"subscriber1": {
+			"channels": {"pub_channel_1", "pub_channel_2", "pub_channel_3"}, // Channels to subscribe to
+			"patterns": {"pub_channel_[456]"},                               // Patterns to subscribe to
+		},
+		"subscriber2": {
+			"channels": {"pub_channel_6", "pub_channel_7"}, // Channels to subscribe to
+			"patterns": {"pub_channel_[891]"},              // Patterns to subscribe to
+		},
+	}
+
+	// Create subscriber one and subscribe to channels and patterns
+	r1, w1 := net.Pipe()
+	rc1 := resp.NewConn(r1)
+	subscribe(ctx, subscriptions["subscriber1"]["channels"], subscriptions["subscriber1"]["patterns"], &w1, rc1)
+
+	// Create subscriber two and subscribe to channels and patterns
+	r2, w2 := net.Pipe()
+	rc2 := resp.NewConn(r2)
+	subscribe(ctx, subscriptions["subscriber2"]["channels"], subscriptions["subscriber2"]["patterns"], &w2, rc2)
+
+	type SubscriberType struct {
+		c *net.Conn
+		r *resp.Conn
+		l string
+	}
+
+	tests := []struct {
+		channel     string
+		message     string
+		subscribers []SubscriberType
+	}{
+		{
+			channel: "pub_channel_1",
+			message: "Test both subscribers 1",
+			subscribers: []SubscriberType{
+				{c: &r1, r: rc1, l: "pub_channel_1"},
+				{c: &r2, r: rc2, l: "pub_channel_[891]"},
+			},
+		},
+		{
+			channel: "pub_channel_6",
+			message: "Test both subscribers 2",
+			subscribers: []SubscriberType{
+				{c: &r1, r: rc1, l: "pub_channel_[456]"},
+				{c: &r2, r: rc2, l: "pub_channel_6"},
+			},
+		},
+		{
+			channel: "pub_channel_2",
+			message: "Test subscriber 1 1",
+			subscribers: []SubscriberType{
+				{c: &r1, r: rc1, l: "pub_channel_2"},
+			},
+		},
+		{
+			channel: "pub_channel_3",
+			message: "Test subscriber 1 2",
+			subscribers: []SubscriberType{
+				{c: &r1, r: rc1, l: "pub_channel_3"},
+			},
+		},
+		{
+			channel: "pub_channel_4",
+			message: "Test both subscribers 2",
+			subscribers: []SubscriberType{
+				{c: &r1, r: rc1, l: "pub_channel_[456]"},
+			},
+		},
+		{
+			channel: "pub_channel_5",
+			message: "Test subscriber 1 3",
+			subscribers: []SubscriberType{
+				{c: &r1, r: rc1, l: "pub_channel_[456]"},
+			},
+		},
+		{
+			channel: "pub_channel_7",
+			message: "Test subscriber 2 1",
+			subscribers: []SubscriberType{
+				{c: &r2, r: rc2, l: "pub_channel_7"},
+			},
+		},
+		{
+			channel: "pub_channel_8",
+			message: "Test subscriber 2 2",
+			subscribers: []SubscriberType{
+				{c: &r1, r: rc2, l: "pub_channel_[891]"},
+			},
+		},
+		{
+			channel: "pub_channel_9",
+			message: "Test subscriber 2 3",
+			subscribers: []SubscriberType{
+				{c: &r2, r: rc2, l: "pub_channel_[891]"},
+			},
+		},
+	}
+
+	// Dial server to make publisher connection
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", bindAddr, port))
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		if err = conn.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	w := resp.NewConn(conn)
+
+	for _, test := range tests {
+		err = w.WriteArray([]resp.Value{
+			resp.StringValue("PUBLISH"),
+			resp.StringValue(test.channel),
+			resp.StringValue(test.message),
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		rv, _, err := w.ReadValue()
+		if err != nil {
+			t.Error(err)
+		}
+		if rv.String() != "OK" {
+			t.Errorf("Expected publish response to be \"OK\", got \"%s\"", rv.String())
+		}
+
+		for _, sub := range test.subscribers {
+			verifyEvent(sub.c, sub.r, []string{"message", sub.l, test.message})
+		}
+	}
+}
 
 func Test_HandlePubSubChannels(t *testing.T) {}
 

--- a/src/modules/pubsub/commands_test.go
+++ b/src/modules/pubsub/commands_test.go
@@ -1,6 +1,21 @@
 package pubsub
 
-import "testing"
+import (
+	"github.com/echovault/echovault/src/server"
+	"github.com/echovault/echovault/src/utils"
+	"testing"
+)
+
+var mockServer *server.Server
+
+func init() {
+	mockServer = server.NewServer(server.Opts{
+		Config: utils.Config{
+			DataDir:        "",
+			EvictionPolicy: utils.NoEviction,
+		},
+	})
+}
 
 func Test_HandleSubscribe(t *testing.T) {
 

--- a/src/modules/pubsub/commands_test.go
+++ b/src/modules/pubsub/commands_test.go
@@ -1,0 +1,27 @@
+package pubsub
+
+import "testing"
+
+func Test_HandleSubscribe(t *testing.T) {
+
+}
+
+func Test_HandleUnsubscribe(t *testing.T) {
+
+}
+
+func Test_HandlePublish(t *testing.T) {
+
+}
+
+func Test_HandlePubSubChannels(t *testing.T) {
+
+}
+
+func Test_HandleNumPat(t *testing.T) {
+
+}
+
+func Test_HandleNumSub(t *testing.T) {
+
+}

--- a/src/modules/pubsub/commands_test.go
+++ b/src/modules/pubsub/commands_test.go
@@ -335,7 +335,7 @@ func Test_HandlePublish(t *testing.T) {
 		}()
 		// Verify all the responses for each pattern subscription
 		for i := 0; i < len(patterns); i++ {
-			verifyEvent(c, r, []string{"subscribe", patterns[i], fmt.Sprintf("%d", i+1)})
+			verifyEvent(c, r, []string{"psubscribe", patterns[i], fmt.Sprintf("%d", i+1)})
 		}
 	}
 

--- a/src/modules/pubsub/commands_test.go
+++ b/src/modules/pubsub/commands_test.go
@@ -1,42 +1,281 @@
 package pubsub
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"github.com/echovault/echovault/src/server"
 	"github.com/echovault/echovault/src/utils"
+	"github.com/tidwall/resp"
+	"net"
+	"slices"
 	"testing"
 )
 
+var pubsub *PubSub
 var mockServer *server.Server
 
+var bindAddr = "localhost"
+var port uint16 = 7490
+
 func init() {
+	pubsub = NewPubSub()
 	mockServer = server.NewServer(server.Opts{
+		PubSub: pubsub,
 		Config: utils.Config{
+			BindAddr:       bindAddr,
+			Port:           port,
 			DataDir:        "",
 			EvictionPolicy: utils.NoEviction,
 		},
 	})
+	go func() {
+		mockServer.Start(context.Background())
+	}()
 }
 
 func Test_HandleSubscribe(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "test_name", "SUBSCRIBE/PSUBSCRIBE")
 
+	numOfConnection := 100
+	connections := make([]*net.Conn, numOfConnection)
+
+	for i := 0; i < numOfConnection; i++ {
+		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", bindAddr, port))
+		if err != nil {
+			t.Error(err)
+		}
+		connections[i] = &conn
+	}
+
+	// Test subscribe to channels
+	channels := []string{"sub_channel1", "sub_channel2", "sub_channel3"}
+	for _, conn := range connections {
+		if _, err := handleSubscribe(ctx, append([]string{"SUBSCRIBE"}, channels...), mockServer, conn); err != nil {
+			t.Error(err)
+		}
+	}
+	for _, channel := range channels {
+		// Check if the channel exists in the pubsub module
+		if !slices.ContainsFunc(pubsub.channels, func(c *Channel) bool {
+			return c.name == channel
+		}) {
+			t.Errorf("expected pubsub to contain channel \"%s\" but it was not found", channel)
+		}
+		for _, c := range pubsub.channels {
+			if c.name == channel {
+				// Check if channel has nil pattern
+				if c.pattern != nil {
+					t.Errorf("expected channel \"%s\" to have nil pattern, found pattern \"%s\"", channel, c.name)
+				}
+				// Check if the channel has all the connections from above
+				for _, conn := range connections {
+					if !slices.Contains(c.subscribers, conn) {
+						t.Errorf("could not find all expected connection in the \"%s\"", channel)
+					}
+				}
+			}
+		}
+	}
+
+	// Test subscribe to patterns
+	patterns := []string{"psub_channel*"}
+	for _, conn := range connections {
+		if _, err := handleSubscribe(ctx, append([]string{"PSUBSCRIBE"}, patterns...), mockServer, conn); err != nil {
+			t.Error(err)
+		}
+	}
+	for _, pattern := range patterns {
+		// Check if pattern channel exists in pubsub module
+		if !slices.ContainsFunc(pubsub.channels, func(c *Channel) bool {
+			return c.name == pattern
+		}) {
+			t.Errorf("expected pubsub to contain pattern channel \"%s\" but it was not found", pattern)
+		}
+		for _, c := range pubsub.channels {
+			if c.name == pattern {
+				// Check if channel has non-nil pattern
+				if c.pattern == nil {
+					t.Errorf("expected channel \"%s\" to have pattern \"%s\", found nil pattern", pattern, c.name)
+				}
+				// Check if the channel has all the connections from above
+				for _, conn := range connections {
+					if !slices.Contains(c.subscribers, conn) {
+						t.Errorf("could not find all expected connection in the \"%s\"", pattern)
+					}
+				}
+			}
+		}
+	}
 }
 
 func Test_HandleUnsubscribe(t *testing.T) {
+	generateConnections := func(noOfConnections int) []*net.Conn {
+		connections := make([]*net.Conn, noOfConnections)
+		for i := 0; i < noOfConnections; i++ {
+			conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", bindAddr, port))
+			if err != nil {
+				t.Error(err)
+			}
+			connections[i] = &conn
+		}
+		return connections
+	}
 
+	verifyResponse := func(res []byte, expectedResponse [][]string) {
+		rd := resp.NewReader(bytes.NewReader(res))
+		rv, _, err := rd.ReadValue()
+		if err != nil {
+			t.Error(err)
+		}
+		v := rv.Array()
+		if len(v) != len(expectedResponse) {
+			t.Errorf("expected subscribe response of length %d, but got %d", len(expectedResponse), len(v))
+		}
+		for _, item := range v {
+			arr := item.Array()
+			if len(arr) != 3 {
+				t.Errorf("expected subscribe response item to be length %d, but got %d", 3, len(arr))
+			}
+			if !slices.ContainsFunc(expectedResponse, func(strings []string) bool {
+				return strings[0] == arr[0].String() && strings[1] == arr[1].String() && strings[2] == arr[2].String()
+			}) {
+				t.Errorf("expected to find item \"%s\" in response, did not find it.", arr[1].String())
+			}
+		}
+	}
+
+	tests := []struct {
+		subChannels       []string              // All channels to subscribe to
+		subPatterns       []string              // All patterns to subscribe to
+		unSubChannels     []string              // Channels to unsubscribe from
+		unSubPatterns     []string              // Patterns to unsubscribe from
+		remainChannels    []string              // Channels to remain subscribed to
+		remainPatterns    []string              // Patterns to remain subscribed to
+		targetConn        *net.Conn             // Connection used to test unsubscribe functionality
+		otherConnections  []*net.Conn           // Connections to fill the subscribers list for channels and patterns
+		expectedResponses map[string][][]string // The expected response from the handler
+	}{
+		{ // 1. Unsubscribe from channels and patterns
+			subChannels:      []string{"xx_channel_one", "xx_channel_two", "xx_channel_three", "xx_channel_four"},
+			subPatterns:      []string{"xx_pattern_[ab]", "xx_pattern_[cd]", "xx_pattern_[ef]", "xx_pattern_[gh]"},
+			unSubChannels:    []string{"xx_channel_one", "xx_channel_two"},
+			unSubPatterns:    []string{"xx_pattern_[ab]"},
+			remainChannels:   []string{"xx_channel_three", "xx_channel_four"},
+			remainPatterns:   []string{"xx_pattern_[cd]", "xx_pattern_[ef]", "xx_pattern_[gh]"},
+			targetConn:       generateConnections(1)[0],
+			otherConnections: generateConnections(20),
+			expectedResponses: map[string][][]string{
+				"channel": {
+					{"unsubscribe", "xx_channel_one", "1"},
+					{"unsubscribe", "xx_channel_two", "2"},
+				},
+				"pattern": {
+					{"punsubscribe", "xx_pattern_[ab]", "1"},
+				},
+			},
+		},
+		{ // 2. Unsubscribe from all channels no channel or pattern is passed to command
+			subChannels:      []string{"xx_channel_one", "xx_channel_two", "xx_channel_three", "xx_channel_four"},
+			subPatterns:      []string{"xx_pattern_[ab]", "xx_pattern_[cd]", "xx_pattern_[ef]", "xx_pattern_[gh]"},
+			unSubChannels:    []string{},
+			unSubPatterns:    []string{},
+			remainChannels:   []string{},
+			remainPatterns:   []string{},
+			targetConn:       generateConnections(1)[0],
+			otherConnections: generateConnections(20),
+			expectedResponses: map[string][][]string{
+				"channel": {
+					{"unsubscribe", "xx_channel_one", "1"},
+					{"unsubscribe", "xx_channel_two", "2"},
+					{"unsubscribe", "xx_channel_three", "3"},
+					{"unsubscribe", "xx_channel_four", "4"},
+				},
+				"pattern": {
+					{"punsubscribe", "xx_pattern_[ab]", "1"},
+					{"punsubscribe", "xx_pattern_[cd]", "2"},
+					{"punsubscribe", "xx_pattern_[ef]", "3"},
+					{"punsubscribe", "xx_pattern_[gh]", "4"},
+				},
+			},
+		},
+		{ // 3. Don't unsubscribe from any channels or patterns if the provided ones are non-existent
+			subChannels:      []string{"xx_channel_one", "xx_channel_two", "xx_channel_three", "xx_channel_four"},
+			subPatterns:      []string{"xx_pattern_[ab]", "xx_pattern_[cd]", "xx_pattern_[ef]", "xx_pattern_[gh]"},
+			unSubChannels:    []string{"xx_channel_non_existent_channel"},
+			unSubPatterns:    []string{"xx_channel_non_existent_pattern_[ae]"},
+			remainChannels:   []string{"xx_channel_one", "xx_channel_two", "xx_channel_three", "xx_channel_four"},
+			remainPatterns:   []string{"xx_pattern_[ab]", "xx_pattern_[cd]", "xx_pattern_[ef]", "xx_pattern_[gh]"},
+			targetConn:       generateConnections(1)[0],
+			otherConnections: generateConnections(20),
+			expectedResponses: map[string][][]string{
+				"channel": {},
+				"pattern": {},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		ctx := context.WithValue(context.Background(), "test_name", fmt.Sprintf("UNSUBSCRIBE/PUNSUBSCRIBE, %d", i))
+
+		// Subscribe all the connections to the channels and patterns
+		for _, conn := range append(test.otherConnections, test.targetConn) {
+			_, err := handleSubscribe(ctx, append([]string{"SUBSCRIBE"}, test.subChannels...), mockServer, conn)
+			if err != nil {
+				t.Error(err)
+			}
+			_, err = handleSubscribe(ctx, append([]string{"PSUBSCRIBE"}, test.subPatterns...), mockServer, conn)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+
+		// Unsubscribe the target connection from the unsub channels and patterns
+		res, err := handleUnsubscribe(ctx, append([]string{"UNSUBSCRIBE"}, test.unSubChannels...), mockServer, test.targetConn)
+		if err != nil {
+			t.Error(err)
+		}
+		verifyResponse(res, test.expectedResponses["channel"])
+
+		res, err = handleUnsubscribe(ctx, append([]string{"PUNSUBSCRIBE"}, test.unSubPatterns...), mockServer, test.targetConn)
+		if err != nil {
+			t.Error(err)
+		}
+		verifyResponse(res, test.expectedResponses["pattern"])
+
+		for _, channel := range append(test.unSubChannels, test.unSubPatterns...) {
+			for _, pubsubChannel := range pubsub.channels {
+				if pubsubChannel.name == channel {
+					// Assert that target connection is no longer in the unsub channels and patterns
+					if slices.Contains(pubsubChannel.subscribers, test.targetConn) {
+						t.Errorf("found unexpected target connection after unsubscrining in channel \"%s\"", channel)
+					}
+					for _, conn := range test.otherConnections {
+						if !slices.Contains(pubsubChannel.subscribers, conn) {
+							t.Errorf("did not find expected other connection in channel \"%s\"", channel)
+						}
+					}
+				}
+			}
+		}
+
+		// Assert that the target connection is still in the remain channels and patterns
+		for _, channel := range append(test.remainChannels, test.remainPatterns...) {
+			for _, pubsubChannel := range pubsub.channels {
+				if pubsubChannel.name == channel {
+					if !slices.Contains(pubsubChannel.subscribers, test.targetConn) {
+						t.Errorf("cound not find expected target connection in channel \"%s\"", channel)
+					}
+				}
+			}
+		}
+	}
 }
 
-func Test_HandlePublish(t *testing.T) {
+func Test_HandlePublish(t *testing.T) {}
 
-}
+func Test_HandlePubSubChannels(t *testing.T) {}
 
-func Test_HandlePubSubChannels(t *testing.T) {
+func Test_HandleNumPat(t *testing.T) {}
 
-}
-
-func Test_HandleNumPat(t *testing.T) {
-
-}
-
-func Test_HandleNumSub(t *testing.T) {
-
-}
+func Test_HandleNumSub(t *testing.T) {}

--- a/src/modules/pubsub/pubsub.go
+++ b/src/modules/pubsub/pubsub.go
@@ -237,6 +237,7 @@ func (ps *PubSub) NumSub(channels []string) []byte {
 
 	res := fmt.Sprintf("*%d\r\n", len(channels))
 	for _, channel := range channels {
+		// If it's a pattern channel, skip it
 		chanIdx := slices.IndexFunc(ps.channels, func(c *Channel) bool {
 			return c.name == channel
 		})

--- a/src/modules/pubsub/pubsub.go
+++ b/src/modules/pubsub/pubsub.go
@@ -25,6 +25,9 @@ func NewPubSub() *PubSub {
 }
 
 func (ps *PubSub) Subscribe(ctx context.Context, conn *net.Conn, channels []string, withPattern bool) {
+	ps.channelsRWMut.Lock()
+	defer ps.channelsRWMut.Unlock()
+
 	r := resp.NewConn(*conn)
 
 	action := "subscribe"
@@ -76,7 +79,7 @@ func (ps *PubSub) Subscribe(ctx context.Context, conn *net.Conn, channels []stri
 
 func (ps *PubSub) Unsubscribe(ctx context.Context, conn *net.Conn, channels []string, withPattern bool) []byte {
 	ps.channelsRWMut.RLock()
-	ps.channelsRWMut.RUnlock()
+	defer ps.channelsRWMut.RUnlock()
 
 	action := "unsubscribe"
 	if withPattern {
@@ -179,6 +182,9 @@ func (ps *PubSub) Publish(ctx context.Context, message string, channelName strin
 }
 
 func (ps *PubSub) Channels(pattern string) []byte {
+	ps.channelsRWMut.RLock()
+	defer ps.channelsRWMut.RUnlock()
+
 	var count int
 	var res string
 

--- a/src/modules/pubsub/pubsub.go
+++ b/src/modules/pubsub/pubsub.go
@@ -218,7 +218,10 @@ func (ps *PubSub) Channels(pattern string) []byte {
 	return []byte(fmt.Sprintf("*%d\r\n%s", count, res))
 }
 
-func (ps *PubSub) NumPat(ctx context.Context) int {
+func (ps *PubSub) NumPat() int {
+	ps.channelsRWMut.RLock()
+	defer ps.channelsRWMut.RUnlock()
+
 	var count int
 	for _, channel := range ps.channels {
 		if channel.pattern != nil {
@@ -228,7 +231,10 @@ func (ps *PubSub) NumPat(ctx context.Context) int {
 	return count
 }
 
-func (ps *PubSub) NumSub(ctx context.Context, channels []string) []byte {
+func (ps *PubSub) NumSub(channels []string) []byte {
+	ps.channelsRWMut.RLock()
+	defer ps.channelsRWMut.RUnlock()
+
 	res := fmt.Sprintf("*%d\r\n", len(channels))
 	for _, channel := range channels {
 		chanIdx := slices.IndexFunc(ps.channels, func(c *Channel) bool {

--- a/src/modules/pubsub/pubsub.go
+++ b/src/modules/pubsub/pubsub.go
@@ -209,7 +209,7 @@ func (ps *PubSub) Channels(pattern string) []byte {
 		}
 	}
 
-	return []byte(res)
+	return []byte(fmt.Sprintf("*%d\r\n%s", count, res))
 }
 
 func (ps *PubSub) NumPat(ctx context.Context) int {

--- a/src/modules/pubsub/pubsub.go
+++ b/src/modules/pubsub/pubsub.go
@@ -224,7 +224,7 @@ func (ps *PubSub) NumPat() int {
 
 	var count int
 	for _, channel := range ps.channels {
-		if channel.pattern != nil {
+		if channel.pattern != nil && channel.IsActive() {
 			count += 1
 		}
 	}

--- a/src/modules/sorted_set/commands_test.go
+++ b/src/modules/sorted_set/commands_test.go
@@ -14,9 +14,18 @@ import (
 	"testing"
 )
 
-func Test_HandleZADD(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
+var mockServer *server.Server
 
+func init() {
+	mockServer = server.NewServer(server.Opts{
+		Config: utils.Config{
+			DataDir:        "",
+			EvictionPolicy: utils.NoEviction,
+		},
+	})
+}
+
+func Test_HandleZADD(t *testing.T) {
 	tests := []struct {
 		preset           bool
 		presetValue      *SortedSet
@@ -29,8 +38,8 @@ func Test_HandleZADD(t *testing.T) {
 		{ // 1. Create new sorted set and return the cardinality of the new sorted set.
 			preset:      false,
 			presetValue: nil,
-			key:         "key1",
-			command:     []string{"ZADD", "key1", "5.5", "member1", "67.77", "member2", "10", "member3", "-inf", "member4", "+inf", "member5"},
+			key:         "ZaddKey1",
+			command:     []string{"ZADD", "ZaddKey1", "5.5", "member1", "67.77", "member2", "10", "member3", "-inf", "member4", "+inf", "member5"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(5.5)},
 				{value: "member2", score: Score(67.77)},
@@ -48,8 +57,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key2",
-			command: []string{"ZADD", "key2", "NX", "5.5", "member1", "67.77", "member4", "10", "member5"},
+			key:     "ZaddKey2",
+			command: []string{"ZADD", "ZaddKey2", "NX", "5.5", "member1", "67.77", "member4", "10", "member5"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(5.5)},
 				{value: "member2", score: Score(67.77)},
@@ -67,8 +76,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key3",
-			command: []string{"ZADD", "key3", "NX", "5.5", "member1", "67.77", "member2", "10", "member3"},
+			key:     "ZaddKey3",
+			command: []string{"ZADD", "ZaddKey3", "NX", "5.5", "member1", "67.77", "member2", "10", "member3"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(5.5)},
 				{value: "member2", score: Score(67.77)},
@@ -84,8 +93,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key4",
-			command: []string{"ZADD", "key4", "XX", "CH", "55", "member1", "1005", "member2", "15", "member3", "99.75", "member4"},
+			key:     "ZaddKey4",
+			command: []string{"ZADD", "ZaddKey4", "XX", "CH", "55", "member1", "1005", "member2", "15", "member3", "99.75", "member4"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(55)},
 				{value: "member2", score: Score(1005)},
@@ -101,8 +110,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key5",
-			command: []string{"ZADD", "key5", "XX", "5.5", "member4", "100.5", "member5", "15", "member6"},
+			key:     "ZaddKey5",
+			command: []string{"ZADD", "ZaddKey5", "XX", "5.5", "member4", "100.5", "member5", "15", "member6"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(5.5)},
 				{value: "member2", score: Score(67.77)},
@@ -119,8 +128,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key6",
-			command: []string{"ZADD", "key6", "XX", "CH", "GT", "7.5", "member1", "100.5", "member4", "15", "member5"},
+			key:     "ZaddKey6",
+			command: []string{"ZADD", "ZaddKey6", "XX", "CH", "GT", "7.5", "member1", "100.5", "member4", "15", "member5"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(7.5)},
 				{value: "member2", score: Score(67.77)},
@@ -137,8 +146,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key7",
-			command: []string{"ZADD", "key7", "XX", "LT", "3.5", "member1", "100.5", "member4", "15", "member5"},
+			key:     "ZaddKey7",
+			command: []string{"ZADD", "ZaddKey7", "XX", "LT", "3.5", "member1", "100.5", "member4", "15", "member5"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(3.5)},
 				{value: "member2", score: Score(67.77)},
@@ -154,8 +163,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key8",
-			command: []string{"ZADD", "key8", "XX", "LT", "CH", "3.5", "member1", "100.5", "member4", "15", "member5"},
+			key:     "ZaddKey8",
+			command: []string{"ZADD", "ZaddKey8", "XX", "LT", "CH", "3.5", "member1", "100.5", "member4", "15", "member5"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(3.5)},
 				{value: "member2", score: Score(67.77)},
@@ -171,8 +180,8 @@ func Test_HandleZADD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:     "key9",
-			command: []string{"ZADD", "key9", "INCR", "5.5", "member3"},
+			key:     "ZaddKey9",
+			command: []string{"ZADD", "ZaddKey9", "INCR", "5.5", "member3"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "member1", score: Score(5.5)},
 				{value: "member2", score: Score(67.77)},
@@ -184,8 +193,8 @@ func Test_HandleZADD(t *testing.T) {
 		{ // 10. Fail when GT/LT flag is provided alongside NX flag
 			preset:           false,
 			presetValue:      nil,
-			key:              "key10",
-			command:          []string{"ZADD", "key10", "NX", "LT", "CH", "3.5", "member1", "100.5", "member4", "15", "member5"},
+			key:              "ZaddKey10",
+			command:          []string{"ZADD", "ZaddKey10", "NX", "LT", "CH", "3.5", "member1", "100.5", "member4", "15", "member5"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New("GT/LT flags not allowed if NX flag is provided"),
@@ -193,8 +202,8 @@ func Test_HandleZADD(t *testing.T) {
 		{ // 11. Command is too short
 			preset:           false,
 			presetValue:      nil,
-			key:              "key11",
-			command:          []string{"ZADD", "key11"},
+			key:              "ZaddKey11",
+			command:          []string{"ZADD", "ZaddKey11"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
@@ -202,8 +211,8 @@ func Test_HandleZADD(t *testing.T) {
 		{ // 12. Throw error when score/member entries are do not match
 			preset:           false,
 			presetValue:      nil,
-			key:              "key11",
-			command:          []string{"ZADD", "key12", "10.5", "member1", "12.5"},
+			key:              "ZaddKey11",
+			command:          []string{"ZADD", "ZaddKey12", "10.5", "member1", "12.5"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New("score/member pairs must be float/string"),
@@ -211,8 +220,8 @@ func Test_HandleZADD(t *testing.T) {
 		{ // 13. Throw error when INCR flag is passed with more than one score/member pair
 			preset:           false,
 			presetValue:      nil,
-			key:              "key13",
-			command:          []string{"ZADD", "key13", "INCR", "10.5", "member1", "12.5", "member2"},
+			key:              "ZaddKey13",
+			command:          []string{"ZADD", "ZaddKey13", "INCR", "10.5", "member1", "12.5", "member2"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New("cannot pass more than one score/member pair when INCR flag is provided"),
@@ -268,8 +277,6 @@ func Test_HandleZADD(t *testing.T) {
 }
 
 func Test_HandleZCARD(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValue      interface{}
@@ -286,8 +293,8 @@ func Test_HandleZCARD(t *testing.T) {
 				{value: "member2", score: Score(67.77)},
 				{value: "member3", score: Score(10)},
 			}),
-			key:              "key1",
-			command:          []string{"ZCARD", "key1"},
+			key:              "ZcardKey1",
+			command:          []string{"ZCARD", "ZcardKey1"},
 			expectedValue:    nil,
 			expectedResponse: 3,
 			expectedError:    nil,
@@ -295,8 +302,8 @@ func Test_HandleZCARD(t *testing.T) {
 		{ // 2. Return 0 when trying to get cardinality from non-existent key
 			preset:           false,
 			presetValue:      nil,
-			key:              "key2",
-			command:          []string{"ZCARD", "key2"},
+			key:              "ZcardKey2",
+			command:          []string{"ZCARD", "ZcardKey2"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    nil,
@@ -304,7 +311,7 @@ func Test_HandleZCARD(t *testing.T) {
 		{ // 3. Command is too short
 			preset:           false,
 			presetValue:      nil,
-			key:              "key3",
+			key:              "ZcardKey3",
 			command:          []string{"ZCARD"},
 			expectedValue:    nil,
 			expectedResponse: 0,
@@ -313,8 +320,8 @@ func Test_HandleZCARD(t *testing.T) {
 		{ // 4. Command too long
 			preset:           false,
 			presetValue:      nil,
-			key:              "key4",
-			command:          []string{"ZCARD", "key4", "key5"},
+			key:              "ZcardKey4",
+			command:          []string{"ZCARD", "ZcardKey4", "ZcardKey5"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
@@ -322,11 +329,11 @@ func Test_HandleZCARD(t *testing.T) {
 		{ // 5. Return error when not a sorted set
 			preset:           true,
 			presetValue:      "Default value",
-			key:              "key5",
-			command:          []string{"ZCARD", "key5"},
+			key:              "ZcardKey5",
+			command:          []string{"ZCARD", "ZcardKey5"},
 			expectedValue:    nil,
 			expectedResponse: 0,
-			expectedError:    errors.New("value at key5 is not a sorted set"),
+			expectedError:    errors.New("value at ZcardKey5 is not a sorted set"),
 		},
 	}
 
@@ -364,8 +371,6 @@ func Test_HandleZCARD(t *testing.T) {
 }
 
 func Test_HandleZCOUNT(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValue      interface{}
@@ -386,8 +391,8 @@ func Test_HandleZCOUNT(t *testing.T) {
 				{value: "member6", score: Score(math.Inf(-1))},
 				{value: "member7", score: Score(math.Inf(1))},
 			}),
-			key:              "key1",
-			command:          []string{"ZCOUNT", "key1", "-inf", "+inf"},
+			key:              "ZcountKey1",
+			command:          []string{"ZCOUNT", "ZcountKey1", "-inf", "+inf"},
 			expectedValue:    nil,
 			expectedResponse: 7,
 			expectedError:    nil,
@@ -403,8 +408,8 @@ func Test_HandleZCOUNT(t *testing.T) {
 				{value: "member6", score: Score(math.Inf(-1))},
 				{value: "member7", score: Score(math.Inf(1))},
 			}),
-			key:              "key2",
-			command:          []string{"ZCOUNT", "key2", "-inf", "90"},
+			key:              "ZcountKey2",
+			command:          []string{"ZCOUNT", "ZcountKey2", "-inf", "90"},
 			expectedValue:    nil,
 			expectedResponse: 5,
 			expectedError:    nil,
@@ -420,8 +425,8 @@ func Test_HandleZCOUNT(t *testing.T) {
 				{value: "member6", score: Score(math.Inf(-1))},
 				{value: "member7", score: Score(math.Inf(1))},
 			}),
-			key:              "key3",
-			command:          []string{"ZCOUNT", "key3", "1000", "+inf"},
+			key:              "ZcountKey3",
+			command:          []string{"ZCOUNT", "ZcountKey3", "1000", "+inf"},
 			expectedValue:    nil,
 			expectedResponse: 2,
 			expectedError:    nil,
@@ -429,8 +434,8 @@ func Test_HandleZCOUNT(t *testing.T) {
 		{ // 4. Return error when bottom boundary is not a valid double/float
 			preset:           false,
 			presetValue:      nil,
-			key:              "key4",
-			command:          []string{"ZCOUNT", "key4", "min", "10"},
+			key:              "ZcountKey4",
+			command:          []string{"ZCOUNT", "ZcountKey4", "min", "10"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New("min constraint must be a double"),
@@ -438,8 +443,8 @@ func Test_HandleZCOUNT(t *testing.T) {
 		{ // 5. Return error when top boundary is not a valid double/float
 			preset:           false,
 			presetValue:      nil,
-			key:              "key5",
-			command:          []string{"ZCOUNT", "key5", "-10", "max"},
+			key:              "ZcountKey5",
+			command:          []string{"ZCOUNT", "ZcountKey5", "-10", "max"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New("max constraint must be a double"),
@@ -447,7 +452,7 @@ func Test_HandleZCOUNT(t *testing.T) {
 		{ // 6. Command is too short
 			preset:           false,
 			presetValue:      nil,
-			key:              "key6",
+			key:              "ZcountKey6",
 			command:          []string{"ZCOUNT"},
 			expectedValue:    nil,
 			expectedResponse: 0,
@@ -456,8 +461,8 @@ func Test_HandleZCOUNT(t *testing.T) {
 		{ // 7. Command too long
 			preset:           false,
 			presetValue:      nil,
-			key:              "key7",
-			command:          []string{"ZCOUNT", "key4", "min", "max", "count"},
+			key:              "ZcountKey7",
+			command:          []string{"ZCOUNT", "ZcountKey4", "min", "max", "count"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
@@ -465,11 +470,11 @@ func Test_HandleZCOUNT(t *testing.T) {
 		{ // 8. Throw error when value at the key is not a sorted set
 			preset:           true,
 			presetValue:      "Default value",
-			key:              "key8",
-			command:          []string{"ZCOUNT", "key8", "1", "10"},
+			key:              "ZcountKey8",
+			command:          []string{"ZCOUNT", "ZcountKey8", "1", "10"},
 			expectedValue:    nil,
 			expectedResponse: 0,
-			expectedError:    errors.New("value at key8 is not a sorted set"),
+			expectedError:    errors.New("value at ZcountKey8 is not a sorted set"),
 		},
 	}
 
@@ -507,8 +512,6 @@ func Test_HandleZCOUNT(t *testing.T) {
 }
 
 func Test_HandleZLEXCOUNT(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValue      interface{}
@@ -529,8 +532,8 @@ func Test_HandleZLEXCOUNT(t *testing.T) {
 				{value: "j", score: Score(1)},
 				{value: "k", score: Score(1)},
 			}),
-			key:              "key1",
-			command:          []string{"ZLEXCOUNT", "key1", "f", "j"},
+			key:              "ZlexCountKey1",
+			command:          []string{"ZLEXCOUNT", "ZlexCountKey1", "f", "j"},
 			expectedValue:    nil,
 			expectedResponse: 5,
 			expectedError:    nil,
@@ -546,8 +549,8 @@ func Test_HandleZLEXCOUNT(t *testing.T) {
 				{value: "f", score: Score(math.Inf(-1))},
 				{value: "g", score: Score(math.Inf(1))},
 			}),
-			key:              "key2",
-			command:          []string{"ZLEXCOUNT", "key2", "a", "b"},
+			key:              "ZlexCountKey2",
+			command:          []string{"ZLEXCOUNT", "ZlexCountKey2", "a", "b"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    nil,
@@ -555,8 +558,8 @@ func Test_HandleZLEXCOUNT(t *testing.T) {
 		{ // 3. Return 0 when the key does not exist
 			preset:           false,
 			presetValue:      nil,
-			key:              "key3",
-			command:          []string{"ZLEXCOUNT", "key3", "a", "z"},
+			key:              "ZlexCountKey3",
+			command:          []string{"ZLEXCOUNT", "ZlexCountKey3", "a", "z"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    nil,
@@ -564,16 +567,16 @@ func Test_HandleZLEXCOUNT(t *testing.T) {
 		{ // 4. Return error when the value at the key is not a sorted set
 			preset:           true,
 			presetValue:      "Default value",
-			key:              "key4",
-			command:          []string{"ZLEXCOUNT", "key4", "a", "z"},
+			key:              "ZlexCountKey4",
+			command:          []string{"ZLEXCOUNT", "ZlexCountKey4", "a", "z"},
 			expectedValue:    nil,
 			expectedResponse: 0,
-			expectedError:    errors.New("value at key4 is not a sorted set"),
+			expectedError:    errors.New("value at ZlexCountKey4 is not a sorted set"),
 		},
 		{ // 5. Command is too short
 			preset:           false,
 			presetValue:      nil,
-			key:              "key5",
+			key:              "ZlexCountKey5",
 			command:          []string{"ZLEXCOUNT"},
 			expectedValue:    nil,
 			expectedResponse: 0,
@@ -582,8 +585,8 @@ func Test_HandleZLEXCOUNT(t *testing.T) {
 		{ // 6. Command too long
 			preset:           false,
 			presetValue:      nil,
-			key:              "key6",
-			command:          []string{"ZLEXCOUNT", "key6", "min", "max", "count"},
+			key:              "ZlexCountKey6",
+			command:          []string{"ZLEXCOUNT", "ZlexCountKey6", "min", "max", "count"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
@@ -624,8 +627,6 @@ func Test_HandleZLEXCOUNT(t *testing.T) {
 }
 
 func Test_HandleZDIFF(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -636,13 +637,13 @@ func Test_HandleZDIFF(t *testing.T) {
 		{ // 1. Get the difference between 2 sorted sets without scores.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZdiffKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1},
 					{value: "two", score: 2},
 					{value: "three", score: 3},
 					{value: "four", score: 4},
 				}),
-				"key2": NewSortedSet([]MemberParam{
+				"ZdiffKey2": NewSortedSet([]MemberParam{
 					{value: "three", score: 3},
 					{value: "four", score: 4},
 					{value: "five", score: 5},
@@ -651,20 +652,20 @@ func Test_HandleZDIFF(t *testing.T) {
 					{value: "eight", score: 8},
 				}),
 			},
-			command:          []string{"ZDIFF", "key1", "key2"},
+			command:          []string{"ZDIFF", "ZdiffKey1", "ZdiffKey2"},
 			expectedResponse: [][]string{{"one"}, {"two"}},
 			expectedError:    nil,
 		},
 		{ // 2. Get the difference between 2 sorted sets with scores.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZdiffKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1},
 					{value: "two", score: 2},
 					{value: "three", score: 3},
 					{value: "four", score: 4},
 				}),
-				"key2": NewSortedSet([]MemberParam{
+				"ZdiffKey2": NewSortedSet([]MemberParam{
 					{value: "three", score: 3},
 					{value: "four", score: 4},
 					{value: "five", score: 5},
@@ -673,45 +674,45 @@ func Test_HandleZDIFF(t *testing.T) {
 					{value: "eight", score: 8},
 				}),
 			},
-			command:          []string{"ZDIFF", "key1", "key2", "WITHSCORES"},
+			command:          []string{"ZDIFF", "ZdiffKey1", "ZdiffKey2", "WITHSCORES"},
 			expectedResponse: [][]string{{"one", "1"}, {"two", "2"}},
 			expectedError:    nil,
 		},
 		{ // 3. Get the difference between 3 sets with scores.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZdiffKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key4": NewSortedSet([]MemberParam{
+				"ZdiffKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key5": NewSortedSet([]MemberParam{
+				"ZdiffKey5": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZDIFF", "key3", "key4", "key5", "WITHSCORES"},
+			command:          []string{"ZDIFF", "ZdiffKey3", "ZdiffKey4", "ZdiffKey5", "WITHSCORES"},
 			expectedResponse: [][]string{{"three", "3"}, {"four", "4"}, {"five", "5"}, {"six", "6"}},
 			expectedError:    nil,
 		},
 		{ // 3. Return sorted set if only one key exists and is a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZdiffKey6": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			command: []string{"ZDIFF", "key6", "key7", "key8", "WITHSCORES"},
+			command: []string{"ZDIFF", "ZdiffKey6", "ZdiffKey7", "ZdiffKey8", "WITHSCORES"},
 			expectedResponse: [][]string{
 				{"one", "1"}, {"two", "2"}, {"three", "3"}, {"four", "4"}, {"five", "5"},
 				{"six", "6"}, {"seven", "7"}, {"eight", "8"},
@@ -721,21 +722,21 @@ func Test_HandleZDIFF(t *testing.T) {
 		{ // 4. Throw error when one of the keys is not a sorted set.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": "Default value",
-				"key10": NewSortedSet([]MemberParam{
+				"ZdiffKey9": "Default value",
+				"ZdiffKey10": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZdiffKey11": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZDIFF", "key9", "key10", "key11"},
+			command:          []string{"ZDIFF", "ZdiffKey9", "ZdiffKey10", "ZdiffKey11"},
 			expectedResponse: nil,
-			expectedError:    errors.New("value at key9 is not a sorted set"),
+			expectedError:    errors.New("value at ZdiffKey9 is not a sorted set"),
 		},
 		{ // 6. Command too short
 			preset:           false,
@@ -794,8 +795,6 @@ func Test_HandleZDIFF(t *testing.T) {
 }
 
 func Test_HandleZDIFFSTORE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -808,19 +807,19 @@ func Test_HandleZDIFFSTORE(t *testing.T) {
 		{ // 1. Get the difference between 2 sorted sets.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
-				"key2": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey2": NewSortedSet([]MemberParam{
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination:      "destination1",
-			command:          []string{"ZDIFFSTORE", "destination1", "key1", "key2"},
+			destination:      "ZdiffStoreDestinationKey1",
+			command:          []string{"ZDIFFSTORE", "ZdiffStoreDestinationKey1", "ZdiffStoreKey1", "ZdiffStoreKey2"},
 			expectedValue:    NewSortedSet([]MemberParam{{value: "one", score: 1}, {value: "two", score: 2}}),
 			expectedResponse: 2,
 			expectedError:    nil,
@@ -828,25 +827,25 @@ func Test_HandleZDIFFSTORE(t *testing.T) {
 		{ // 2. Get the difference between 3 sorted sets.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key4": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key5": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey5": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination2",
-			command:     []string{"ZDIFFSTORE", "destination2", "key3", "key4", "key5"},
+			destination: "ZdiffStoreDestinationKey2",
+			command:     []string{"ZDIFFSTORE", "ZdiffStoreDestinationKey2", "ZdiffStoreKey3", "ZdiffStoreKey4", "ZdiffStoreKey5"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5}, {value: "six", score: 6},
@@ -857,15 +856,15 @@ func Test_HandleZDIFFSTORE(t *testing.T) {
 		{ // 3. Return base sorted set element if base set is the only existing key provided and is a valid sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey6": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination: "destination3",
-			command:     []string{"ZDIFFSTORE", "destination3", "key6", "key7", "key8"},
+			destination: "ZdiffStoreDestinationKey3",
+			command:     []string{"ZDIFFSTORE", "ZdiffStoreDestinationKey3", "ZdiffStoreKey6", "ZdiffStoreKey7", "ZdiffStoreKey8"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "two", score: 2},
 				{value: "three", score: 3}, {value: "four", score: 4},
@@ -878,47 +877,47 @@ func Test_HandleZDIFFSTORE(t *testing.T) {
 		{ // 4. Throw error when base sorted set is not a set.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": "Default value",
-				"key10": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey9": "Default value",
+				"ZdiffStoreKey10": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey11": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination:      "destination4",
-			command:          []string{"ZDIFFSTORE", "destination4", "key9", "key10", "key11"},
+			destination:      "ZdiffStoreDestinationKey4",
+			command:          []string{"ZDIFFSTORE", "ZdiffStoreDestinationKey4", "ZdiffStoreKey9", "ZdiffStoreKey10", "ZdiffStoreKey11"},
 			expectedValue:    nil,
 			expectedResponse: 0,
-			expectedError:    errors.New("value at key9 is not a sorted set"),
+			expectedError:    errors.New("value at ZdiffStoreKey9 is not a sorted set"),
 		},
 		{ // 5. Throw error when base set is non-existent.
 			preset:      true,
-			destination: "destination5",
+			destination: "ZdiffStoreDestinationKey5",
 			presetValues: map[string]interface{}{
-				"key12": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey12": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key13": NewSortedSet([]MemberParam{
+				"ZdiffStoreKey13": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZDIFFSTORE", "destination5", "non-existent", "key12", "key13"},
+			command:          []string{"ZDIFFSTORE", "ZdiffStoreDestinationKey5", "non-existent", "ZdiffStoreKey12", "ZdiffStoreKey13"},
 			expectedValue:    nil,
 			expectedResponse: 0,
 			expectedError:    nil,
 		},
 		{ // 6. Command too short
 			preset:           false,
-			command:          []string{"ZDIFFSTORE", "destination6"},
+			command:          []string{"ZDIFFSTORE", "ZdiffStoreDestinationKey6"},
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
@@ -975,8 +974,6 @@ func Test_HandleZDIFFSTORE(t *testing.T) {
 }
 
 func Test_HandleZINCRBY(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValue      interface{}
@@ -993,8 +990,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 				{value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5},
 			}),
-			key:     "key1",
-			command: []string{"ZINCRBY", "key1", "5", "one"},
+			key:     "ZincrbyKey1",
+			command: []string{"ZINCRBY", "ZincrbyKey1", "5", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 6}, {value: "two", score: 2},
 				{value: "three", score: 3}, {value: "four", score: 4},
@@ -1010,8 +1007,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 				{value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5},
 			}),
-			key:     "key2",
-			command: []string{"ZINCRBY", "key2", "346.785", "one"},
+			key:     "ZincrbyKey2",
+			command: []string{"ZINCRBY", "ZincrbyKey2", "346.785", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 347.785}, {value: "two", score: 2},
 				{value: "three", score: 3}, {value: "four", score: 4},
@@ -1023,8 +1020,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 		{ // 3. Increment on non-existent sorted set will create the set with the member and increment as its score
 			preset:      false,
 			presetValue: nil,
-			key:         "key3",
-			command:     []string{"ZINCRBY", "key3", "346.785", "one"},
+			key:         "ZincrbyKey3",
+			command:     []string{"ZINCRBY", "ZincrbyKey3", "346.785", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 346.785},
 			}),
@@ -1038,8 +1035,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 				{value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5},
 			}),
-			key:     "key4",
-			command: []string{"ZINCRBY", "key4", "+inf", "one"},
+			key:     "ZincrbyKey4",
+			command: []string{"ZINCRBY", "ZincrbyKey4", "+inf", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: Score(math.Inf(1))}, {value: "two", score: 2},
 				{value: "three", score: 3}, {value: "four", score: 4},
@@ -1055,8 +1052,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 				{value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5},
 			}),
-			key:     "key5",
-			command: []string{"ZINCRBY", "key5", "-inf", "one"},
+			key:     "ZincrbyKey5",
+			command: []string{"ZINCRBY", "ZincrbyKey5", "-inf", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: Score(math.Inf(-1))}, {value: "two", score: 2},
 				{value: "three", score: 3}, {value: "four", score: 4},
@@ -1072,8 +1069,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 				{value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5},
 			}),
-			key:     "key6",
-			command: []string{"ZINCRBY", "key6", "-2.5", "five"},
+			key:     "ZincrbyKey6",
+			command: []string{"ZINCRBY", "ZincrbyKey6", "-2.5", "five"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "two", score: 2},
 				{value: "three", score: 3}, {value: "four", score: 4},
@@ -1085,19 +1082,19 @@ func Test_HandleZINCRBY(t *testing.T) {
 		{ // 7. Return error when attempting to increment on a value that is not a valid sorted set
 			preset:           true,
 			presetValue:      "Default value",
-			key:              "key7",
-			command:          []string{"ZINCRBY", "key7", "-2.5", "five"},
+			key:              "ZincrbyKey7",
+			command:          []string{"ZINCRBY", "ZincrbyKey7", "-2.5", "five"},
 			expectedValue:    nil,
 			expectedResponse: "",
-			expectedError:    errors.New("value at key7 is not a sorted set"),
+			expectedError:    errors.New("value at ZincrbyKey7 is not a sorted set"),
 		},
 		{ // 8. Return error when trying to increment a member that already has score -inf
 			preset: true,
 			presetValue: NewSortedSet([]MemberParam{
 				{value: "one", score: Score(math.Inf(-1))},
 			}),
-			key:     "key8",
-			command: []string{"ZINCRBY", "key8", "2.5", "one"},
+			key:     "ZincrbyKey8",
+			command: []string{"ZINCRBY", "ZincrbyKey8", "2.5", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: Score(math.Inf(-1))},
 			}),
@@ -1109,8 +1106,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 			presetValue: NewSortedSet([]MemberParam{
 				{value: "one", score: Score(math.Inf(1))},
 			}),
-			key:     "key9",
-			command: []string{"ZINCRBY", "key9", "2.5", "one"},
+			key:     "ZincrbyKey9",
+			command: []string{"ZINCRBY", "ZincrbyKey9", "2.5", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: Score(math.Inf(-1))},
 			}),
@@ -1122,8 +1119,8 @@ func Test_HandleZINCRBY(t *testing.T) {
 			presetValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1},
 			}),
-			key:     "key10",
-			command: []string{"ZINCRBY", "key10", "increment", "one"},
+			key:     "ZincrbyKey10",
+			command: []string{"ZINCRBY", "ZincrbyKey10", "increment", "one"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1},
 			}),
@@ -1131,14 +1128,14 @@ func Test_HandleZINCRBY(t *testing.T) {
 			expectedError:    errors.New("increment must be a double"),
 		},
 		{ // 11. Command too short
-			key:              "key11",
-			command:          []string{"ZINCRBY", "key11", "one"},
+			key:              "ZincrbyKey11",
+			command:          []string{"ZINCRBY", "ZincrbyKey11", "one"},
 			expectedResponse: "",
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // 12. Command too long
-			key:              "key12",
-			command:          []string{"ZINCRBY", "key12", "one", "1", "2"},
+			key:              "ZincrbyKey12",
+			command:          []string{"ZINCRBY", "ZincrbyKey12", "one", "1", "2"},
 			expectedResponse: "",
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
@@ -1200,8 +1197,6 @@ func Test_HandleZINCRBY(t *testing.T) {
 }
 
 func Test_HandleZMPOP(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -1213,15 +1208,15 @@ func Test_HandleZMPOP(t *testing.T) {
 		{ // 1. Successfully pop one min element by default
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZmpopKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
 			},
-			command: []string{"ZMPOP", "key1"},
+			command: []string{"ZMPOP", "ZmpopKey1"},
 			expectedValues: map[string]*SortedSet{
-				"key1": NewSortedSet([]MemberParam{
+				"ZmpopKey1": NewSortedSet([]MemberParam{
 					{value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
@@ -1235,15 +1230,15 @@ func Test_HandleZMPOP(t *testing.T) {
 		{ // 2. Successfully pop one min element by specifying MIN
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key2": NewSortedSet([]MemberParam{
+				"ZmpopKey2": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
 			},
-			command: []string{"ZMPOP", "key2", "MIN"},
+			command: []string{"ZMPOP", "ZmpopKey2", "MIN"},
 			expectedValues: map[string]*SortedSet{
-				"key2": NewSortedSet([]MemberParam{
+				"ZmpopKey2": NewSortedSet([]MemberParam{
 					{value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
@@ -1257,15 +1252,15 @@ func Test_HandleZMPOP(t *testing.T) {
 		{ // 3. Successfully pop one max element by specifying MAX modifier
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZmpopKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
 			},
-			command: []string{"ZMPOP", "key3", "MAX"},
+			command: []string{"ZMPOP", "ZmpopKey3", "MAX"},
 			expectedValues: map[string]*SortedSet{
-				"key3": NewSortedSet([]MemberParam{
+				"ZmpopKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 				}),
@@ -1278,15 +1273,15 @@ func Test_HandleZMPOP(t *testing.T) {
 		{ // 4. Successfully pop multiple min elements
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key4": NewSortedSet([]MemberParam{
+				"ZmpopKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 				}),
 			},
-			command: []string{"ZMPOP", "key4", "MIN", "COUNT", "5"},
+			command: []string{"ZMPOP", "ZmpopKey4", "MIN", "COUNT", "5"},
 			expectedValues: map[string]*SortedSet{
-				"key4": NewSortedSet([]MemberParam{
+				"ZmpopKey4": NewSortedSet([]MemberParam{
 					{value: "six", score: 6},
 				}),
 			},
@@ -1299,15 +1294,15 @@ func Test_HandleZMPOP(t *testing.T) {
 		{ // 5. Successfully pop multiple max elements
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key5": NewSortedSet([]MemberParam{
+				"ZmpopKey5": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 				}),
 			},
-			command: []string{"ZMPOP", "key5", "MAX", "COUNT", "5"},
+			command: []string{"ZMPOP", "ZmpopKey5", "MAX", "COUNT", "5"},
 			expectedValues: map[string]*SortedSet{
-				"key5": NewSortedSet([]MemberParam{
+				"ZmpopKey5": NewSortedSet([]MemberParam{
 					{value: "one", score: 1},
 				}),
 			},
@@ -1317,17 +1312,17 @@ func Test_HandleZMPOP(t *testing.T) {
 		{ // 6. Successfully pop elements from the first set which is non-empty
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{}),
-				"key7": NewSortedSet([]MemberParam{
+				"ZmpopKey6": NewSortedSet([]MemberParam{}),
+				"ZmpopKey7": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 				}),
 			},
-			command: []string{"ZMPOP", "key6", "key7", "MAX", "COUNT", "5"},
+			command: []string{"ZMPOP", "ZmpopKey6", "ZmpopKey7", "MAX", "COUNT", "5"},
 			expectedValues: map[string]*SortedSet{
-				"key6": NewSortedSet([]MemberParam{}),
-				"key7": NewSortedSet([]MemberParam{
+				"ZmpopKey6": NewSortedSet([]MemberParam{}),
+				"ZmpopKey7": NewSortedSet([]MemberParam{
 					{value: "one", score: 1},
 				}),
 			},
@@ -1337,19 +1332,19 @@ func Test_HandleZMPOP(t *testing.T) {
 		{ // 7. Skip the non-set items and pop elements from the first non-empty sorted set found
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key8":  "Default value",
-				"key9":  56,
-				"key10": NewSortedSet([]MemberParam{}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZmpopKey8":  "Default value",
+				"ZmpopKey9":  56,
+				"ZmpopKey10": NewSortedSet([]MemberParam{}),
+				"ZmpopKey11": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 				}),
 			},
-			command: []string{"ZMPOP", "key8", "key9", "key10", "key11", "MIN", "COUNT", "5"},
+			command: []string{"ZMPOP", "ZmpopKey8", "ZmpopKey9", "ZmpopKey10", "ZmpopKey11", "MIN", "COUNT", "5"},
 			expectedValues: map[string]*SortedSet{
-				"key10": NewSortedSet([]MemberParam{}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZmpopKey10": NewSortedSet([]MemberParam{}),
+				"ZmpopKey11": NewSortedSet([]MemberParam{
 					{value: "six", score: 6},
 				}),
 			},
@@ -1358,7 +1353,7 @@ func Test_HandleZMPOP(t *testing.T) {
 		},
 		{ // 9. Return error when count is a negative integer
 			preset:        false,
-			command:       []string{"ZMPOP", "key8", "MAX", "COUNT", "-20"},
+			command:       []string{"ZMPOP", "ZmpopKey8", "MAX", "COUNT", "-20"},
 			expectedError: errors.New("count must be a positive integer"),
 		},
 		{ // 9. Command too short
@@ -1429,8 +1424,6 @@ func Test_HandleZMPOP(t *testing.T) {
 }
 
 func Test_HandleZPOP(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -1442,15 +1435,15 @@ func Test_HandleZPOP(t *testing.T) {
 		{ // 1. Successfully pop one min element by default
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZmpopMinKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
 			},
-			command: []string{"ZPOPMIN", "key1"},
+			command: []string{"ZPOPMIN", "ZmpopMinKey1"},
 			expectedValues: map[string]*SortedSet{
-				"key1": NewSortedSet([]MemberParam{
+				"ZmpopMinKey1": NewSortedSet([]MemberParam{
 					{value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
@@ -1464,15 +1457,15 @@ func Test_HandleZPOP(t *testing.T) {
 		{ // 2. Successfully pop one max element by default
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key2": NewSortedSet([]MemberParam{
+				"ZmpopMaxKey2": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
 			},
-			command: []string{"ZPOPMAX", "key2"},
+			command: []string{"ZPOPMAX", "ZmpopMaxKey2"},
 			expectedValues: map[string]*SortedSet{
-				"key2": NewSortedSet([]MemberParam{
+				"ZmpopMaxKey2": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 				}),
@@ -1485,15 +1478,15 @@ func Test_HandleZPOP(t *testing.T) {
 		{ // 3. Successfully pop multiple min elements
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZmpopMinKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 				}),
 			},
-			command: []string{"ZPOPMIN", "key3", "5"},
+			command: []string{"ZPOPMIN", "ZmpopMinKey3", "5"},
 			expectedValues: map[string]*SortedSet{
-				"key3": NewSortedSet([]MemberParam{
+				"ZmpopMinKey3": NewSortedSet([]MemberParam{
 					{value: "six", score: 6},
 				}),
 			},
@@ -1506,15 +1499,15 @@ func Test_HandleZPOP(t *testing.T) {
 		{ // 4. Successfully pop multiple max elements
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key4": NewSortedSet([]MemberParam{
+				"ZmpopMaxKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 				}),
 			},
-			command: []string{"ZPOPMAX", "key4", "5"},
+			command: []string{"ZPOPMAX", "ZmpopMaxKey4", "5"},
 			expectedValues: map[string]*SortedSet{
-				"key4": NewSortedSet([]MemberParam{
+				"ZmpopMaxKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1},
 				}),
 			},
@@ -1524,12 +1517,12 @@ func Test_HandleZPOP(t *testing.T) {
 		{ // 5. Throw an error when trying to pop from an element that's not a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key5": "Default value",
+				"ZmpopMinKey5": "Default value",
 			},
-			command:          []string{"ZPOPMIN", "key5"},
+			command:          []string{"ZPOPMIN", "ZmpopMinKey5"},
 			expectedValues:   nil,
 			expectedResponse: nil,
-			expectedError:    errors.New("value at key key5 is not a sorted set"),
+			expectedError:    errors.New("value at key ZmpopMinKey5 is not a sorted set"),
 		},
 		{ // 6. Command too short
 			preset:        false,
@@ -1538,7 +1531,7 @@ func Test_HandleZPOP(t *testing.T) {
 		},
 		{ // 7. Command too long
 			preset:        false,
-			command:       []string{"ZPOPMAX", "key7", "6", "3"},
+			command:       []string{"ZPOPMAX", "ZmpopMaxKey7", "6", "3"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 	}
@@ -1604,8 +1597,6 @@ func Test_HandleZPOP(t *testing.T) {
 }
 
 func Test_HandleZMSCORE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -1617,28 +1608,28 @@ func Test_HandleZMSCORE(t *testing.T) {
 			// Return nil for elements that do not exist in the sorted set.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZmScoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1.1}, {value: "two", score: 245},
 					{value: "three", score: 3}, {value: "four", score: 4.055},
 					{value: "five", score: 5},
 				}),
 			},
-			command:          []string{"ZMSCORE", "key1", "one", "none", "two", "one", "three", "four", "none", "five"},
+			command:          []string{"ZMSCORE", "ZmScoreKey1", "one", "none", "two", "one", "three", "four", "none", "five"},
 			expectedResponse: []interface{}{"1.1", nil, "245", "1.1", "3", "4.055", nil, "5"},
 			expectedError:    nil,
 		},
 		{ // 2. If key does not exist, return empty array
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZMSCORE", "key2", "one", "two", "three", "four"},
+			command:          []string{"ZMSCORE", "ZmScoreKey2", "one", "two", "three", "four"},
 			expectedResponse: []interface{}{},
 			expectedError:    nil,
 		},
 		{ // 3. Throw error when trying to find scores from elements that are not sorted sets
 			preset:        true,
-			presetValues:  map[string]interface{}{"key3": "Default value"},
-			command:       []string{"ZMSCORE", "key3", "one", "two", "three"},
-			expectedError: errors.New("value at key3 is not a sorted set"),
+			presetValues:  map[string]interface{}{"ZmScoreKey3": "Default value"},
+			command:       []string{"ZMSCORE", "ZmScoreKey3", "one", "two", "three"},
+			expectedError: errors.New("value at ZmScoreKey3 is not a sorted set"),
 		},
 		{ // 9. Command too short
 			preset:        false,
@@ -1691,8 +1682,6 @@ func Test_HandleZMSCORE(t *testing.T) {
 }
 
 func Test_HandleZSCORE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -1703,41 +1692,41 @@ func Test_HandleZSCORE(t *testing.T) {
 		{ // 1. Return score from a sorted set.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZscoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1.1}, {value: "two", score: 245},
 					{value: "three", score: 3}, {value: "four", score: 4.055},
 					{value: "five", score: 5},
 				}),
 			},
-			command:          []string{"ZSCORE", "key1", "four"},
+			command:          []string{"ZSCORE", "ZscoreKey1", "four"},
 			expectedResponse: "4.055",
 			expectedError:    nil,
 		},
 		{ // 2. If key does not exist, return nil value
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZSCORE", "key2", "one"},
+			command:          []string{"ZSCORE", "ZscoreKey2", "one"},
 			expectedResponse: nil,
 			expectedError:    nil,
 		},
 		{ // 3. If key exists and is a sorted set, but the member does not exist, return nil
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZscoreKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1.1}, {value: "two", score: 245},
 					{value: "three", score: 3}, {value: "four", score: 4.055},
 					{value: "five", score: 5},
 				}),
 			},
-			command:          []string{"ZSCORE", "key3", "non-existent"},
+			command:          []string{"ZSCORE", "ZscoreKey3", "non-existent"},
 			expectedResponse: nil,
 			expectedError:    nil,
 		},
 		{ // 4. Throw error when trying to find scores from elements that are not sorted sets
 			preset:        true,
-			presetValues:  map[string]interface{}{"key4": "Default value"},
-			command:       []string{"ZSCORE", "key4", "one"},
-			expectedError: errors.New("value at key4 is not a sorted set"),
+			presetValues:  map[string]interface{}{"ZscoreKey4": "Default value"},
+			command:       []string{"ZSCORE", "ZscoreKey4", "one"},
+			expectedError: errors.New("value at ZscoreKey4 is not a sorted set"),
 		},
 		{ // 5. Command too short
 			preset:        false,
@@ -1746,7 +1735,7 @@ func Test_HandleZSCORE(t *testing.T) {
 		},
 		{ // 6. Command too long
 			preset:        false,
-			command:       []string{"ZSCORE", "key5", "one", "two"},
+			command:       []string{"ZSCORE", "ZscoreKey5", "one", "two"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 	}
@@ -1793,8 +1782,6 @@ func Test_HandleZSCORE(t *testing.T) {
 }
 
 func Test_HandleZRANDMEMBER(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -1808,12 +1795,12 @@ func Test_HandleZRANDMEMBER(t *testing.T) {
 		{ // 1. Return multiple random elements without removing them
 			// Count is positive, do not allow repeated elements
 			preset: true,
-			key:    "key1",
+			key:    "ZrandMemberKey1",
 			presetValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "two", score: 2}, {value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5}, {value: "six", score: 6}, {value: "seven", score: 7}, {value: "eight", score: 8},
 			}),
-			command:       []string{"ZRANDMEMBER", "key1", "3"},
+			command:       []string{"ZRANDMEMBER", "ZrandMemberKey1", "3"},
 			expectedValue: 8,
 			allowRepeat:   false,
 			expectedResponse: [][]string{
@@ -1826,12 +1813,12 @@ func Test_HandleZRANDMEMBER(t *testing.T) {
 			// 2. Return multiple random elements and their scores without removing them.
 			// Count is negative, so allow repeated numbers.
 			preset: true,
-			key:    "key2",
+			key:    "ZrandMemberKey2",
 			presetValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "two", score: 2}, {value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5}, {value: "six", score: 6}, {value: "seven", score: 7}, {value: "eight", score: 8},
 			}),
-			command:       []string{"ZRANDMEMBER", "key2", "-5", "WITHSCORES"},
+			command:       []string{"ZRANDMEMBER", "ZrandMemberKey2", "-5", "WITHSCORES"},
 			expectedValue: 8,
 			allowRepeat:   true,
 			expectedResponse: [][]string{
@@ -1842,11 +1829,11 @@ func Test_HandleZRANDMEMBER(t *testing.T) {
 		},
 		{ // 2. Return error when the source key is not a sorted set.
 			preset:        true,
-			key:           "key3",
+			key:           "ZrandMemberKey3",
 			presetValue:   "Default value",
-			command:       []string{"ZRANDMEMBER", "key3"},
+			command:       []string{"ZRANDMEMBER", "ZrandMemberKey3"},
 			expectedValue: 0,
-			expectedError: errors.New("value at key3 is not a sorted set"),
+			expectedError: errors.New("value at ZrandMemberKey3 is not a sorted set"),
 		},
 		{ // 5. Command too short
 			preset:        false,
@@ -1860,12 +1847,12 @@ func Test_HandleZRANDMEMBER(t *testing.T) {
 		},
 		{ // 7. Throw error when count is not an integer
 			preset:        false,
-			command:       []string{"SRANDMEMBER", "key1", "count"},
+			command:       []string{"ZRANDMEMBER", "ZrandMemberKey1", "count"},
 			expectedError: errors.New("count must be an integer"),
 		},
 		{ // 8. Throw error when the fourth argument is not WITHSCORES
 			preset:        false,
-			command:       []string{"SRANDMEMBER", "key1", "8", "ANOTHER"},
+			command:       []string{"ZRANDMEMBER", "ZrandMemberKey1", "8", "ANOTHER"},
 			expectedError: errors.New("last option must be WITHSCORES"),
 		},
 	}
@@ -1956,8 +1943,6 @@ func Test_HandleZRANDMEMBER(t *testing.T) {
 }
 
 func Test_HandleZRANK(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -1968,54 +1953,54 @@ func Test_HandleZRANK(t *testing.T) {
 		{ // 1. Return element's rank from a sorted set.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZrankKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
 			},
-			command:          []string{"ZRANK", "key1", "four"},
+			command:          []string{"ZRANK", "ZrankKey1", "four"},
 			expectedResponse: []string{"3"},
 			expectedError:    nil,
 		},
 		{ // 2. Return element's rank from a sorted set with its score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZrankKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 100.1}, {value: "two", score: 245},
 					{value: "three", score: 305.43}, {value: "four", score: 411.055},
 					{value: "five", score: 500},
 				}),
 			},
-			command:          []string{"ZRANK", "key1", "four", "WITHSCORES"},
+			command:          []string{"ZRANK", "ZrankKey1", "four", "WITHSCORES"},
 			expectedResponse: []string{"3", "411.055"},
 			expectedError:    nil,
 		},
 		{ // 3. If key does not exist, return nil value
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANK", "key3", "one"},
+			command:          []string{"ZRANK", "ZrankKey3", "one"},
 			expectedResponse: nil,
 			expectedError:    nil,
 		},
 		{ // 4. If key exists and is a sorted set, but the member does not exist, return nil
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key4": NewSortedSet([]MemberParam{
+				"ZrankKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1.1}, {value: "two", score: 245},
 					{value: "three", score: 3}, {value: "four", score: 4.055},
 					{value: "five", score: 5},
 				}),
 			},
-			command:          []string{"ZRANK", "key4", "non-existent"},
+			command:          []string{"ZRANK", "ZrankKey4", "non-existent"},
 			expectedResponse: nil,
 			expectedError:    nil,
 		},
 		{ // 5. Throw error when trying to find scores from elements that are not sorted sets
 			preset:        true,
-			presetValues:  map[string]interface{}{"key5": "Default value"},
-			command:       []string{"ZRANK", "key5", "one"},
-			expectedError: errors.New("value at key5 is not a sorted set"),
+			presetValues:  map[string]interface{}{"ZrankKey5": "Default value"},
+			command:       []string{"ZRANK", "ZrankKey5", "one"},
+			expectedError: errors.New("value at ZrankKey5 is not a sorted set"),
 		},
 		{ // 5. Command too short
 			preset:        false,
@@ -2024,7 +2009,7 @@ func Test_HandleZRANK(t *testing.T) {
 		},
 		{ // 6. Command too long
 			preset:        false,
-			command:       []string{"ZRANK", "key5", "one", "WITHSCORES", "two"},
+			command:       []string{"ZRANK", "ZrankKey5", "one", "WITHSCORES", "two"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 	}
@@ -2076,8 +2061,6 @@ func Test_HandleZRANK(t *testing.T) {
 }
 
 func Test_HandleZREM(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -2090,7 +2073,7 @@ func Test_HandleZREM(t *testing.T) {
 			// Return deleted count.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
@@ -2098,9 +2081,9 @@ func Test_HandleZREM(t *testing.T) {
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
 			},
-			command: []string{"ZREM", "key1", "three", "four", "five", "none", "six", "none", "seven"},
+			command: []string{"ZREM", "ZremKey1", "three", "four", "five", "none", "six", "none", "seven"},
 			expectedValues: map[string]*SortedSet{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
@@ -2111,7 +2094,7 @@ func Test_HandleZREM(t *testing.T) {
 		{ // 2. If key does not exist, return 0
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZREM", "key2", "member"},
+			command:          []string{"ZREM", "ZremKey2", "member"},
 			expectedValues:   nil,
 			expectedResponse: 0,
 			expectedError:    nil,
@@ -2119,10 +2102,10 @@ func Test_HandleZREM(t *testing.T) {
 		{ // 3. Return error key is not a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": "Default value",
+				"ZremKey3": "Default value",
 			},
-			command:       []string{"ZREM", "key3", "member"},
-			expectedError: errors.New("value at key3 is not a sorted set"),
+			command:       []string{"ZREM", "ZremKey3", "member"},
+			expectedError: errors.New("value at ZremKey3 is not a sorted set"),
 		},
 		{ // 9. Command too short
 			preset:        false,
@@ -2182,8 +2165,6 @@ func Test_HandleZREM(t *testing.T) {
 }
 
 func Test_HandleZREMRANGEBYSCORE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -2195,7 +2176,7 @@ func Test_HandleZREMRANGEBYSCORE(t *testing.T) {
 		{ // 1. Successfully remove multiple elements with scores inside the provided range
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremRangeByScoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
@@ -2203,9 +2184,9 @@ func Test_HandleZREMRANGEBYSCORE(t *testing.T) {
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
 			},
-			command: []string{"ZREMRANGEBYSCORE", "key1", "3", "7"},
+			command: []string{"ZREMRANGEBYSCORE", "ZremRangeByScoreKey1", "3", "7"},
 			expectedValues: map[string]*SortedSet{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremRangeByScoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
@@ -2216,7 +2197,7 @@ func Test_HandleZREMRANGEBYSCORE(t *testing.T) {
 		{ // 2. If key does not exist, return 0
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZREMRANGEBYSCORE", "key2", "2", "4"},
+			command:          []string{"ZREMRANGEBYSCORE", "ZremRangeByScoreKey2", "2", "4"},
 			expectedValues:   nil,
 			expectedResponse: 0,
 			expectedError:    nil,
@@ -2224,19 +2205,19 @@ func Test_HandleZREMRANGEBYSCORE(t *testing.T) {
 		{ // 3. Return error key is not a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": "Default value",
+				"ZremRangeByScoreKey3": "Default value",
 			},
-			command:       []string{"ZREMRANGEBYSCORE", "key3", "4", "4"},
-			expectedError: errors.New("value at key3 is not a sorted set"),
+			command:       []string{"ZREMRANGEBYSCORE", "ZremRangeByScoreKey3", "4", "4"},
+			expectedError: errors.New("value at ZremRangeByScoreKey3 is not a sorted set"),
 		},
 		{ // 4. Command too short
 			preset:        false,
-			command:       []string{"ZREMRANGEBYSCORE", "key4", "3"},
+			command:       []string{"ZREMRANGEBYSCORE", "ZremRangeByScoreKey4", "3"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 		{ // 5. Command too long
 			preset:        false,
-			command:       []string{"ZREMRANGEBYSCORE", "key5", "4", "5", "8"},
+			command:       []string{"ZREMRANGEBYSCORE", "ZremRangeByScoreKey5", "4", "5", "8"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 	}
@@ -2292,8 +2273,6 @@ func Test_HandleZREMRANGEBYSCORE(t *testing.T) {
 }
 
 func Test_HandleZREMRANGEBYRANK(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -2305,7 +2284,7 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 		{ // 1. Successfully remove multiple elements within range
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremRangeByRankKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
@@ -2313,9 +2292,9 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
 			},
-			command: []string{"ZREMRANGEBYRANK", "key1", "0", "5"},
+			command: []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey1", "0", "5"},
 			expectedValues: map[string]*SortedSet{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremRangeByRankKey1": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
@@ -2326,7 +2305,7 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 		{ // 2. Establish boundaries from the end of the set when negative boundaries are provided
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key2": NewSortedSet([]MemberParam{
+				"ZremRangeByRankKey2": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
@@ -2334,9 +2313,9 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
 			},
-			command: []string{"ZREMRANGEBYRANK", "key2", "-6", "-3"},
+			command: []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey2", "-6", "-3"},
 			expectedValues: map[string]*SortedSet{
-				"key2": NewSortedSet([]MemberParam{
+				"ZremRangeByRankKey2": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
@@ -2348,7 +2327,7 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 		{ // 2. If key does not exist, return 0
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZREMRANGEBYRANK", "key3", "2", "4"},
+			command:          []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey3", "2", "4"},
 			expectedValues:   nil,
 			expectedResponse: 0,
 			expectedError:    nil,
@@ -2356,20 +2335,20 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 		{ // 3. Return error key is not a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": "Default value",
+				"ZremRangeByRankKey3": "Default value",
 			},
-			command:       []string{"ZREMRANGEBYRANK", "key3", "4", "4"},
-			expectedError: errors.New("value at key3 is not a sorted set"),
+			command:       []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey3", "4", "4"},
+			expectedError: errors.New("value at ZremRangeByRankKey3 is not a sorted set"),
 		},
 		{ // 4. Command too short
 			preset:        false,
-			command:       []string{"ZREMRANGEBYRANK", "key4", "3"},
+			command:       []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey4", "3"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 		{ // 5. Return error when start index is out of bounds
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key5": NewSortedSet([]MemberParam{
+				"ZremRangeByRankKey5": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
@@ -2377,7 +2356,7 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
 			},
-			command:          []string{"ZREMRANGEBYRANK", "key5", "-12", "5"},
+			command:          []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey5", "-12", "5"},
 			expectedValues:   nil,
 			expectedResponse: 0,
 			expectedError:    errors.New("indices out of bounds"),
@@ -2385,7 +2364,7 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 		{ // 6. Return error when end index is out of bounds
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZremRangeByRankKey6": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
@@ -2393,14 +2372,14 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 				}),
 			},
-			command:          []string{"ZREMRANGEBYRANK", "key6", "0", "11"},
+			command:          []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey6", "0", "11"},
 			expectedValues:   nil,
 			expectedResponse: 0,
 			expectedError:    errors.New("indices out of bounds"),
 		},
 		{ // 7. Command too long
 			preset:        false,
-			command:       []string{"ZREMRANGEBYRANK", "key7", "4", "5", "8"},
+			command:       []string{"ZREMRANGEBYRANK", "ZremRangeByRankKey7", "4", "5", "8"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 	}
@@ -2456,8 +2435,6 @@ func Test_HandleZREMRANGEBYRANK(t *testing.T) {
 }
 
 func Test_HandleZREMRANGEBYLEX(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -2469,7 +2446,7 @@ func Test_HandleZREMRANGEBYLEX(t *testing.T) {
 		{ // 1. Successfully remove multiple elements with scores inside the provided range
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremRangeByLexKey1": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 1},
 					{value: "c", score: 1}, {value: "d", score: 1},
 					{value: "e", score: 1}, {value: "f", score: 1},
@@ -2477,9 +2454,9 @@ func Test_HandleZREMRANGEBYLEX(t *testing.T) {
 					{value: "i", score: 1}, {value: "j", score: 1},
 				}),
 			},
-			command: []string{"ZREMRANGEBYLEX", "key1", "a", "d"},
+			command: []string{"ZREMRANGEBYLEX", "ZremRangeByLexKey1", "a", "d"},
 			expectedValues: map[string]*SortedSet{
-				"key1": NewSortedSet([]MemberParam{
+				"ZremRangeByLexKey1": NewSortedSet([]MemberParam{
 					{value: "e", score: 1}, {value: "f", score: 1},
 					{value: "g", score: 1}, {value: "h", score: 1},
 					{value: "i", score: 1}, {value: "j", score: 1},
@@ -2491,7 +2468,7 @@ func Test_HandleZREMRANGEBYLEX(t *testing.T) {
 		{ // 2. Return 0 if the members do not have the same score
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key2": NewSortedSet([]MemberParam{
+				"ZremRangeByLexKey2": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 2},
 					{value: "c", score: 3}, {value: "d", score: 4},
 					{value: "e", score: 5}, {value: "f", score: 6},
@@ -2499,9 +2476,9 @@ func Test_HandleZREMRANGEBYLEX(t *testing.T) {
 					{value: "i", score: 9}, {value: "j", score: 10},
 				}),
 			},
-			command: []string{"ZREMRANGEBYLEX", "key2", "d", "g"},
+			command: []string{"ZREMRANGEBYLEX", "ZremRangeByLexKey2", "d", "g"},
 			expectedValues: map[string]*SortedSet{
-				"key2": NewSortedSet([]MemberParam{
+				"ZremRangeByLexKey2": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 2},
 					{value: "c", score: 3}, {value: "d", score: 4},
 					{value: "e", score: 5}, {value: "f", score: 6},
@@ -2515,7 +2492,7 @@ func Test_HandleZREMRANGEBYLEX(t *testing.T) {
 		{ // 3. If key does not exist, return 0
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZREMRANGEBYLEX", "key3", "2", "4"},
+			command:          []string{"ZREMRANGEBYLEX", "ZremRangeByLexKey3", "2", "4"},
 			expectedValues:   nil,
 			expectedResponse: 0,
 			expectedError:    nil,
@@ -2523,19 +2500,19 @@ func Test_HandleZREMRANGEBYLEX(t *testing.T) {
 		{ // 3. Return error key is not a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": "Default value",
+				"ZremRangeByLexKey3": "Default value",
 			},
-			command:       []string{"ZREMRANGEBYLEX", "key3", "a", "d"},
-			expectedError: errors.New("value at key3 is not a sorted set"),
+			command:       []string{"ZREMRANGEBYLEX", "ZremRangeByLexKey3", "a", "d"},
+			expectedError: errors.New("value at ZremRangeByLexKey3 is not a sorted set"),
 		},
 		{ // 4. Command too short
 			preset:        false,
-			command:       []string{"ZREMRANGEBYLEX", "key4", "a"},
+			command:       []string{"ZREMRANGEBYLEX", "ZremRangeByLexKey4", "a"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 		{ // 5. Command too long
 			preset:        false,
-			command:       []string{"ZREMRANGEBYLEX", "key5", "a", "b", "c"},
+			command:       []string{"ZREMRANGEBYLEX", "ZremRangeByLexKey5", "a", "b", "c"},
 			expectedError: errors.New(utils.WrongArgsResponse),
 		},
 	}
@@ -2591,8 +2568,6 @@ func Test_HandleZREMRANGEBYLEX(t *testing.T) {
 }
 
 func Test_HandleZRANGE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -2603,28 +2578,28 @@ func Test_HandleZRANGE(t *testing.T) {
 		{ // 1. Get elements withing score range without score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZrangeKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			command:          []string{"ZRANGE", "key1", "3", "7", "BYSCORE"},
+			command:          []string{"ZRANGE", "ZrangeKey1", "3", "7", "BYSCORE"},
 			expectedResponse: [][]string{{"three"}, {"four"}, {"five"}, {"six"}, {"seven"}},
 			expectedError:    nil,
 		},
 		{ // 2. Get elements within score range with score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key2": NewSortedSet([]MemberParam{
+				"ZrangeKey2": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			command: []string{"ZRANGE", "key2", "3", "7", "BYSCORE", "WITHSCORES"},
+			command: []string{"ZRANGE", "ZrangeKey2", "3", "7", "BYSCORE", "WITHSCORES"},
 			expectedResponse: [][]string{
 				{"three", "3"}, {"four", "4"}, {"five", "5"},
 				{"six", "6"}, {"seven", "7"}},
@@ -2634,14 +2609,14 @@ func Test_HandleZRANGE(t *testing.T) {
 			// Offset and limit are in where we start and stop counting in the original sorted set (NOT THE RESULT).
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZrangeKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			command:          []string{"ZRANGE", "key3", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4"},
+			command:          []string{"ZRANGE", "ZrangeKey3", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: [][]string{{"three", "3"}, {"four", "4"}, {"five", "5"}},
 			expectedError:    nil,
 		},
@@ -2650,42 +2625,42 @@ func Test_HandleZRANGE(t *testing.T) {
 			// REV reverses the original set before getting the range.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key4": NewSortedSet([]MemberParam{
+				"ZrangeKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			command:          []string{"ZRANGE", "key4", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4", "REV"},
+			command:          []string{"ZRANGE", "ZrangeKey4", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4", "REV"},
 			expectedResponse: [][]string{{"six", "6"}, {"five", "5"}, {"four", "4"}},
 			expectedError:    nil,
 		},
 		{ // 5. Get elements within lex range without score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key5": NewSortedSet([]MemberParam{
+				"ZrangeKey5": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "e", score: 1},
 					{value: "b", score: 1}, {value: "f", score: 1},
 					{value: "c", score: 1}, {value: "g", score: 1},
 					{value: "d", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			command:          []string{"ZRANGE", "key5", "c", "g", "BYLEX"},
+			command:          []string{"ZRANGE", "ZrangeKey5", "c", "g", "BYLEX"},
 			expectedResponse: [][]string{{"c"}, {"d"}, {"e"}, {"f"}, {"g"}},
 			expectedError:    nil,
 		},
 		{ // 6. Get elements within lex range with score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZrangeKey6": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "e", score: 1},
 					{value: "b", score: 1}, {value: "f", score: 1},
 					{value: "c", score: 1}, {value: "g", score: 1},
 					{value: "d", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			command: []string{"ZRANGE", "key6", "a", "f", "BYLEX", "WITHSCORES"},
+			command: []string{"ZRANGE", "ZrangeKey6", "a", "f", "BYLEX", "WITHSCORES"},
 			expectedResponse: [][]string{
 				{"a", "1"}, {"b", "1"}, {"c", "1"},
 				{"d", "1"}, {"e", "1"}, {"f", "1"}},
@@ -2695,14 +2670,14 @@ func Test_HandleZRANGE(t *testing.T) {
 			// Offset and limit are in where we start and stop counting in the original sorted set (NOT THE RESULT).
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key7": NewSortedSet([]MemberParam{
+				"ZrangeKey7": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 1},
 					{value: "c", score: 1}, {value: "d", score: 1},
 					{value: "e", score: 1}, {value: "f", score: 1},
 					{value: "g", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			command:          []string{"ZRANGE", "key7", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
+			command:          []string{"ZRANGE", "ZrangeKey7", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: [][]string{{"c", "1"}, {"d", "1"}, {"e", "1"}},
 			expectedError:    nil,
 		},
@@ -2711,79 +2686,79 @@ func Test_HandleZRANGE(t *testing.T) {
 			// REV reverses the original set before getting the range.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key8": NewSortedSet([]MemberParam{
+				"ZrangeKey8": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 1},
 					{value: "c", score: 1}, {value: "d", score: 1},
 					{value: "e", score: 1}, {value: "f", score: 1},
 					{value: "g", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			command:          []string{"ZRANGE", "key8", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4", "REV"},
+			command:          []string{"ZRANGE", "ZrangeKey8", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4", "REV"},
 			expectedResponse: [][]string{{"f", "1"}, {"e", "1"}, {"d", "1"}},
 			expectedError:    nil,
 		},
 		{ // 9. Return an empty slice when we use BYLEX while elements have different scores
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": NewSortedSet([]MemberParam{
+				"ZrangeKey9": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 5},
 					{value: "c", score: 2}, {value: "d", score: 6},
 					{value: "e", score: 3}, {value: "f", score: 7},
 					{value: "g", score: 4}, {value: "h", score: 8},
 				}),
 			},
-			command:          []string{"ZRANGE", "key9", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
+			command:          []string{"ZRANGE", "ZrangeKey9", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: [][]string{},
 			expectedError:    nil,
 		},
 		{ // 10. Throw error when limit does not provide both offset and limit
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGE", "key10", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2"},
+			command:          []string{"ZRANGE", "ZrangeKey10", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2"},
 			expectedResponse: [][]string{},
 			expectedError:    errors.New("limit should contain offset and count as integers"),
 		},
 		{ // 11. Throw error when offset is not a valid integer
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGE", "key11", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "offset", "4"},
+			command:          []string{"ZRANGE", "ZrangeKey11", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "offset", "4"},
 			expectedResponse: [][]string{},
 			expectedError:    errors.New("limit offset must be integer"),
 		},
 		{ // 12. Throw error when limit is not a valid integer
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGE", "key12", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "4", "limit"},
+			command:          []string{"ZRANGE", "ZrangeKey12", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "4", "limit"},
 			expectedResponse: [][]string{},
 			expectedError:    errors.New("limit count must be integer"),
 		},
 		{ // 13. Throw error when offset is negative
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGE", "key13", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9"},
+			command:          []string{"ZRANGE", "ZrangeKey13", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9"},
 			expectedResponse: [][]string{},
 			expectedError:    errors.New("limit offset must be >= 0"),
 		},
 		{ // 14. Throw error when the key does not hold a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key14": "Default value",
+				"ZrangeKey14": "Default value",
 			},
-			command:          []string{"ZRANGE", "key14", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
+			command:          []string{"ZRANGE", "ZrangeKey14", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: [][]string{},
-			expectedError:    errors.New("value at key14 is not a sorted set"),
+			expectedError:    errors.New("value at ZrangeKey14 is not a sorted set"),
 		},
 		{ // 15. Command too short
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGE", "key15", "1"},
+			command:          []string{"ZRANGE", "ZrangeKey15", "1"},
 			expectedResponse: [][]string{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // 16 Command too long
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGE", "key16", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9", "REV", "WITHSCORES"},
+			command:          []string{"ZRANGE", "ZrangeKey16", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9", "REV", "WITHSCORES"},
 			expectedResponse: [][]string{},
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
@@ -2841,8 +2816,6 @@ func Test_HandleZRANGE(t *testing.T) {
 }
 
 func Test_HandleZRANGESTORE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -2855,15 +2828,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 		{ // 1. Get elements withing score range without score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination:      "destination1",
-			command:          []string{"ZRANGESTORE", "destination1", "key1", "3", "7", "BYSCORE"},
+			destination:      "ZrangeStoreDestinationKey1",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey1", "ZrangeStoreKey1", "3", "7", "BYSCORE"},
 			expectedResponse: 5,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "three", score: 3}, {value: "four", score: 4}, {value: "five", score: 5},
@@ -2874,15 +2847,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 		{ // 2. Get elements within score range with score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key2": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey2": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination:      "destination2",
-			command:          []string{"ZRANGESTORE", "destination2", "key2", "3", "7", "BYSCORE", "WITHSCORES"},
+			destination:      "ZrangeStoreDestinationKey2",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey2", "ZrangeStoreKey2", "3", "7", "BYSCORE", "WITHSCORES"},
 			expectedResponse: 5,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "three", score: 3}, {value: "four", score: 4}, {value: "five", score: 5},
@@ -2894,15 +2867,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 			// Offset and limit are in where we start and stop counting in the original sorted set (NOT THE RESULT).
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination:      "destination3",
-			command:          []string{"ZRANGESTORE", "destination3", "key3", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4"},
+			destination:      "ZrangeStoreDestinationKey3",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey3", "ZrangeStoreKey3", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: 3,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "three", score: 3}, {value: "four", score: 4}, {value: "five", score: 5},
@@ -2914,15 +2887,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 			// REV reverses the original set before getting the range.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key4": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination:      "destination4",
-			command:          []string{"ZRANGESTORE", "destination4", "key4", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4", "REV"},
+			destination:      "ZrangeStoreDestinationKey4",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey4", "ZrangeStoreKey4", "3", "7", "BYSCORE", "WITHSCORES", "LIMIT", "2", "4", "REV"},
 			expectedResponse: 3,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "six", score: 6}, {value: "five", score: 5}, {value: "four", score: 4},
@@ -2932,15 +2905,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 		{ // 5. Get elements within lex range without score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key5": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey5": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "e", score: 1},
 					{value: "b", score: 1}, {value: "f", score: 1},
 					{value: "c", score: 1}, {value: "g", score: 1},
 					{value: "d", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			destination:      "destination5",
-			command:          []string{"ZRANGESTORE", "destination5", "key5", "c", "g", "BYLEX"},
+			destination:      "ZrangeStoreDestinationKey5",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey5", "ZrangeStoreKey5", "c", "g", "BYLEX"},
 			expectedResponse: 5,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "c", score: 1}, {value: "d", score: 1}, {value: "e", score: 1},
@@ -2951,15 +2924,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 		{ // 6. Get elements within lex range with score.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey6": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "e", score: 1},
 					{value: "b", score: 1}, {value: "f", score: 1},
 					{value: "c", score: 1}, {value: "g", score: 1},
 					{value: "d", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			destination:      "destination6",
-			command:          []string{"ZRANGESTORE", "destination6", "key6", "a", "f", "BYLEX", "WITHSCORES"},
+			destination:      "ZrangeStoreDestinationKey6",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey6", "ZrangeStoreKey6", "a", "f", "BYLEX", "WITHSCORES"},
 			expectedResponse: 6,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "a", score: 1}, {value: "b", score: 1}, {value: "c", score: 1},
@@ -2971,15 +2944,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 			// Offset and limit are in where we start and stop counting in the original sorted set (NOT THE RESULT).
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key7": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey7": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 1},
 					{value: "c", score: 1}, {value: "d", score: 1},
 					{value: "e", score: 1}, {value: "f", score: 1},
 					{value: "g", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			destination:      "destination7",
-			command:          []string{"ZRANGESTORE", "destination7", "key7", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
+			destination:      "ZrangeStoreDestinationKey7",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey7", "ZrangeStoreKey7", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: 3,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "c", score: 1}, {value: "d", score: 1}, {value: "e", score: 1},
@@ -2991,15 +2964,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 			// REV reverses the original set before getting the range.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key8": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey8": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 1},
 					{value: "c", score: 1}, {value: "d", score: 1},
 					{value: "e", score: 1}, {value: "f", score: 1},
 					{value: "g", score: 1}, {value: "h", score: 1},
 				}),
 			},
-			destination:      "destination8",
-			command:          []string{"ZRANGESTORE", "destination8", "key8", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4", "REV"},
+			destination:      "ZrangeStoreDestinationKey8",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey8", "ZrangeStoreKey8", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4", "REV"},
 			expectedResponse: 3,
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "f", score: 1}, {value: "e", score: 1}, {value: "d", score: 1},
@@ -3009,15 +2982,15 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 		{ // 9. Return an empty slice when we use BYLEX while elements have different scores
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": NewSortedSet([]MemberParam{
+				"ZrangeStoreKey9": NewSortedSet([]MemberParam{
 					{value: "a", score: 1}, {value: "b", score: 5},
 					{value: "c", score: 2}, {value: "d", score: 6},
 					{value: "e", score: 3}, {value: "f", score: 7},
 					{value: "g", score: 4}, {value: "h", score: 8},
 				}),
 			},
-			destination:      "destination9",
-			command:          []string{"ZRANGESTORE", "destination9", "key9", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
+			destination:      "ZrangeStoreDestinationKey9",
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey9", "ZrangeStoreKey9", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: 0,
 			expectedValue:    nil,
 			expectedError:    nil,
@@ -3025,51 +2998,51 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 		{ // 10. Throw error when limit does not provide both offset and limit
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGESTORE", "destination10", "key10", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2"},
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey10", "ZrangeStoreKey10", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2"},
 			expectedResponse: 0,
 			expectedError:    errors.New("limit should contain offset and count as integers"),
 		},
 		{ // 11. Throw error when offset is not a valid integer
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGESTORE", "destination11", "key11", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "offset", "4"},
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey11", "ZrangeStoreKey11", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "offset", "4"},
 			expectedResponse: 0,
 			expectedError:    errors.New("limit offset must be integer"),
 		},
 		{ // 12. Throw error when limit is not a valid integer
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGESTORE", "destination12", "key12", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "4", "limit"},
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey12", "ZrangeStoreKey12", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "4", "limit"},
 			expectedResponse: 0,
 			expectedError:    errors.New("limit count must be integer"),
 		},
 		{ // 13. Throw error when offset is negative
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGESTORE", "destination13", "key13", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9"},
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey13", "ZrangeStoreKey13", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9"},
 			expectedResponse: 0,
 			expectedError:    errors.New("limit offset must be >= 0"),
 		},
 		{ // 14. Throw error when the key does not hold a sorted set
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key14": "Default value",
+				"ZrangeStoreKey14": "Default value",
 			},
-			command:          []string{"ZRANGESTORE", "destination14", "key14", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey14", "ZrangeStoreKey14", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "2", "4"},
 			expectedResponse: 0,
-			expectedError:    errors.New("value at key14 is not a sorted set"),
+			expectedError:    errors.New("value at ZrangeStoreKey14 is not a sorted set"),
 		},
 		{ // 15. Command too short
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGESTORE", "key15", "1"},
+			command:          []string{"ZRANGESTORE", "ZrangeStoreKey15", "1"},
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
 		{ // 16 Command too long
 			preset:           false,
 			presetValues:     nil,
-			command:          []string{"ZRANGESTORE", "destination16", "key16", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9", "REV", "WITHSCORES"},
+			command:          []string{"ZRANGESTORE", "ZrangeStoreDestinationKey16", "ZrangeStoreKey16", "a", "h", "BYLEX", "WITHSCORES", "LIMIT", "-4", "9", "REV", "WITHSCORES"},
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
@@ -3124,8 +3097,6 @@ func Test_HandleZRANGESTORE(t *testing.T) {
 }
 
 func Test_HandleZINTER(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -3136,18 +3107,18 @@ func Test_HandleZINTER(t *testing.T) {
 		{ // 1. Get the intersection between 2 sorted sets.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZinterKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
-				"key2": NewSortedSet([]MemberParam{
+				"ZinterKey2": NewSortedSet([]MemberParam{
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			command:          []string{"ZINTER", "key1", "key2"},
+			command:          []string{"ZINTER", "ZinterKey1", "ZinterKey2"},
 			expectedResponse: [][]string{{"three"}, {"four"}, {"five"}},
 			expectedError:    nil,
 		},
@@ -3156,24 +3127,24 @@ func Test_HandleZINTER(t *testing.T) {
 			// By default, the SUM aggregate will be used.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZinterKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key4": NewSortedSet([]MemberParam{
+				"ZinterKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 8},
 				}),
-				"key5": NewSortedSet([]MemberParam{
+				"ZinterKey5": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTER", "key3", "key4", "key5", "WITHSCORES"},
+			command:          []string{"ZINTER", "ZinterKey3", "ZinterKey4", "ZinterKey5", "WITHSCORES"},
 			expectedResponse: [][]string{{"one", "3"}, {"eight", "24"}},
 			expectedError:    nil,
 		},
@@ -3182,24 +3153,24 @@ func Test_HandleZINTER(t *testing.T) {
 			// Use MIN aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZinterKey6": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key7": NewSortedSet([]MemberParam{
+				"ZinterKey7": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key8": NewSortedSet([]MemberParam{
+				"ZinterKey8": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTER", "key6", "key7", "key8", "WITHSCORES", "AGGREGATE", "MIN"},
+			command:          []string{"ZINTER", "ZinterKey6", "ZinterKey7", "ZinterKey8", "WITHSCORES", "AGGREGATE", "MIN"},
 			expectedResponse: [][]string{{"one", "1"}, {"eight", "8"}},
 			expectedError:    nil,
 		},
@@ -3208,24 +3179,24 @@ func Test_HandleZINTER(t *testing.T) {
 			// Use MAX aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": NewSortedSet([]MemberParam{
+				"ZinterKey9": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key10": NewSortedSet([]MemberParam{
+				"ZinterKey10": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZinterKey11": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTER", "key9", "key10", "key11", "WITHSCORES", "AGGREGATE", "MAX"},
+			command:          []string{"ZINTER", "ZinterKey9", "ZinterKey10", "ZinterKey11", "WITHSCORES", "AGGREGATE", "MAX"},
 			expectedResponse: [][]string{{"one", "1000"}, {"eight", "800"}},
 			expectedError:    nil,
 		},
@@ -3234,24 +3205,24 @@ func Test_HandleZINTER(t *testing.T) {
 			// Use SUM aggregate with weights modifier.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key12": NewSortedSet([]MemberParam{
+				"ZinterKey12": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key13": NewSortedSet([]MemberParam{
+				"ZinterKey13": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key14": NewSortedSet([]MemberParam{
+				"ZinterKey14": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTER", "key12", "key13", "key14", "WITHSCORES", "AGGREGATE", "SUM", "WEIGHTS", "1", "5", "3"},
+			command:          []string{"ZINTER", "ZinterKey12", "ZinterKey13", "ZinterKey14", "WITHSCORES", "AGGREGATE", "SUM", "WEIGHTS", "1", "5", "3"},
 			expectedResponse: [][]string{{"one", "3105"}, {"eight", "2808"}},
 			expectedError:    nil,
 		},
@@ -3260,24 +3231,24 @@ func Test_HandleZINTER(t *testing.T) {
 			// Use MAX aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key15": NewSortedSet([]MemberParam{
+				"ZinterKey15": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key16": NewSortedSet([]MemberParam{
+				"ZinterKey16": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key17": NewSortedSet([]MemberParam{
+				"ZinterKey17": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTER", "key15", "key16", "key17", "WITHSCORES", "AGGREGATE", "MAX", "WEIGHTS", "1", "5", "3"},
+			command:          []string{"ZINTER", "ZinterKey15", "ZinterKey16", "ZinterKey17", "WITHSCORES", "AGGREGATE", "MAX", "WEIGHTS", "1", "5", "3"},
 			expectedResponse: [][]string{{"one", "3000"}, {"eight", "2400"}},
 			expectedError:    nil,
 		},
@@ -3286,66 +3257,66 @@ func Test_HandleZINTER(t *testing.T) {
 			// Use MIN aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key18": NewSortedSet([]MemberParam{
+				"ZinterKey18": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key19": NewSortedSet([]MemberParam{
+				"ZinterKey19": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key20": NewSortedSet([]MemberParam{
+				"ZinterKey20": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTER", "key18", "key19", "key20", "WITHSCORES", "AGGREGATE", "MIN", "WEIGHTS", "1", "5", "3"},
+			command:          []string{"ZINTER", "ZinterKey18", "ZinterKey19", "ZinterKey20", "WITHSCORES", "AGGREGATE", "MIN", "WEIGHTS", "1", "5", "3"},
 			expectedResponse: [][]string{{"one", "5"}, {"eight", "8"}},
 			expectedError:    nil,
 		},
 		{ // 8. Throw an error if there are more weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key21": NewSortedSet([]MemberParam{
+				"ZinterKey21": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterKey22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZINTER", "key21", "key22", "WEIGHTS", "1", "2", "3"},
+			command:          []string{"ZINTER", "ZinterKey21", "ZinterKey22", "WEIGHTS", "1", "2", "3"},
 			expectedResponse: nil,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 9. Throw an error if there are fewer weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key23": NewSortedSet([]MemberParam{
+				"ZinterKey23": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key24": NewSortedSet([]MemberParam{
+				"ZinterKey24": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 				}),
-				"key25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterKey25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZINTER", "key23", "key24", "key25", "WEIGHTS", "5", "4"},
+			command:          []string{"ZINTER", "ZinterKey23", "ZinterKey24", "ZinterKey25", "WEIGHTS", "5", "4"},
 			expectedResponse: nil,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 10. Throw an error if there are no keys provided
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterKey26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterKey27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterKey28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
 			command:          []string{"ZINTER", "WEIGHTS", "5", "4"},
 			expectedResponse: nil,
@@ -3354,34 +3325,34 @@ func Test_HandleZINTER(t *testing.T) {
 		{ // 11. Throw an error if any of the provided keys are not sorted sets
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key29": NewSortedSet([]MemberParam{
+				"ZinterKey29": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key30": "Default value",
-				"key31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterKey30": "Default value",
+				"ZinterKey31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZINTER", "key29", "key30", "key31"},
+			command:          []string{"ZINTER", "ZinterKey29", "ZinterKey30", "ZinterKey31"},
 			expectedResponse: nil,
-			expectedError:    errors.New("value at key30 is not a sorted set"),
+			expectedError:    errors.New("value at ZinterKey30 is not a sorted set"),
 		},
 		{ // 12. If any of the keys does not exist, return an empty array.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key32": NewSortedSet([]MemberParam{
+				"ZinterKey32": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key33": NewSortedSet([]MemberParam{
+				"ZinterKey33": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTER", "non-existent", "key32", "key33"},
+			command:          []string{"ZINTER", "non-existent", "ZinterKey32", "ZinterKey33"},
 			expectedResponse: [][]string{},
 			expectedError:    nil,
 		},
@@ -3442,8 +3413,6 @@ func Test_HandleZINTER(t *testing.T) {
 }
 
 func Test_HandleZINTERSTORE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -3456,19 +3425,19 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 		{ // 1. Get the intersection between 2 sorted sets.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZinterStoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
-				"key2": NewSortedSet([]MemberParam{
+				"ZinterStoreKey2": NewSortedSet([]MemberParam{
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination: "destination1",
-			command:     []string{"ZINTERSTORE", "destination1", "key1", "key2"},
+			destination: "ZinterStoreDestinationKey1",
+			command:     []string{"ZINTERSTORE", "ZinterStoreDestinationKey1", "ZinterStoreKey1", "ZinterStoreKey2"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5},
@@ -3481,25 +3450,25 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 			// By default, the SUM aggregate will be used.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZinterStoreKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key4": NewSortedSet([]MemberParam{
+				"ZinterStoreKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 8},
 				}),
-				"key5": NewSortedSet([]MemberParam{
+				"ZinterStoreKey5": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination2",
-			command:     []string{"ZINTERSTORE", "destination2", "key3", "key4", "key5", "WITHSCORES"},
+			destination: "ZinterStoreDestinationKey2",
+			command:     []string{"ZINTERSTORE", "ZinterStoreDestinationKey2", "ZinterStoreKey3", "ZinterStoreKey4", "ZinterStoreKey5", "WITHSCORES"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "eight", score: 24},
 			}),
@@ -3511,25 +3480,25 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 			// Use MIN aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZinterStoreKey6": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key7": NewSortedSet([]MemberParam{
+				"ZinterStoreKey7": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key8": NewSortedSet([]MemberParam{
+				"ZinterStoreKey8": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination3",
-			command:     []string{"ZINTERSTORE", "destination3", "key6", "key7", "key8", "WITHSCORES", "AGGREGATE", "MIN"},
+			destination: "ZinterStoreDestinationKey3",
+			command:     []string{"ZINTERSTORE", "ZinterStoreDestinationKey3", "ZinterStoreKey6", "ZinterStoreKey7", "ZinterStoreKey8", "WITHSCORES", "AGGREGATE", "MIN"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "eight", score: 8},
 			}),
@@ -3541,25 +3510,25 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 			// Use MAX aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": NewSortedSet([]MemberParam{
+				"ZinterStoreKey9": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key10": NewSortedSet([]MemberParam{
+				"ZinterStoreKey10": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZinterStoreKey11": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination4",
-			command:     []string{"ZINTERSTORE", "destination4", "key9", "key10", "key11", "WITHSCORES", "AGGREGATE", "MAX"},
+			destination: "ZinterStoreDestinationKey4",
+			command:     []string{"ZINTERSTORE", "ZinterStoreDestinationKey4", "ZinterStoreKey9", "ZinterStoreKey10", "ZinterStoreKey11", "WITHSCORES", "AGGREGATE", "MAX"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1000}, {value: "eight", score: 800},
 			}),
@@ -3571,25 +3540,25 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 			// Use SUM aggregate with weights modifier.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key12": NewSortedSet([]MemberParam{
+				"ZinterStoreKey12": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key13": NewSortedSet([]MemberParam{
+				"ZinterStoreKey13": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key14": NewSortedSet([]MemberParam{
+				"ZinterStoreKey14": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination5",
-			command:     []string{"ZINTERSTORE", "destination5", "key12", "key13", "key14", "WITHSCORES", "AGGREGATE", "SUM", "WEIGHTS", "1", "5", "3"},
+			destination: "ZinterStoreDestinationKey5",
+			command:     []string{"ZINTERSTORE", "ZinterStoreDestinationKey5", "ZinterStoreKey12", "ZinterStoreKey13", "ZinterStoreKey14", "WITHSCORES", "AGGREGATE", "SUM", "WEIGHTS", "1", "5", "3"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "eight", score: 2808},
 			}),
@@ -3601,25 +3570,25 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 			// Use MAX aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key15": NewSortedSet([]MemberParam{
+				"ZinterStoreKey15": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key16": NewSortedSet([]MemberParam{
+				"ZinterStoreKey16": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key17": NewSortedSet([]MemberParam{
+				"ZinterStoreKey17": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination6",
-			command:     []string{"ZINTERSTORE", "destination6", "key15", "key16", "key17", "WITHSCORES", "AGGREGATE", "MAX", "WEIGHTS", "1", "5", "3"},
+			destination: "ZinterStoreDestinationKey6",
+			command:     []string{"ZINTERSTORE", "ZinterStoreDestinationKey6", "ZinterStoreKey15", "ZinterStoreKey16", "ZinterStoreKey17", "WITHSCORES", "AGGREGATE", "MAX", "WEIGHTS", "1", "5", "3"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 3000}, {value: "eight", score: 2400},
 			}),
@@ -3631,25 +3600,25 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 			// Use MIN aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key18": NewSortedSet([]MemberParam{
+				"ZinterStoreKey18": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key19": NewSortedSet([]MemberParam{
+				"ZinterStoreKey19": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key20": NewSortedSet([]MemberParam{
+				"ZinterStoreKey20": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination7",
-			command:     []string{"ZINTERSTORE", "destination7", "key18", "key19", "key20", "WITHSCORES", "AGGREGATE", "MIN", "WEIGHTS", "1", "5", "3"},
+			destination: "ZinterStoreDestinationKey7",
+			command:     []string{"ZINTERSTORE", "ZinterStoreDestinationKey7", "ZinterStoreKey18", "ZinterStoreKey19", "ZinterStoreKey20", "WITHSCORES", "AGGREGATE", "MIN", "WEIGHTS", "1", "5", "3"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 5}, {value: "eight", score: 8},
 			}),
@@ -3659,42 +3628,42 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 		{ // 8. Throw an error if there are more weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key21": NewSortedSet([]MemberParam{
+				"ZinterStoreKey21": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterStoreKey22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZINTERSTORE", "destination8", "key21", "key22", "WEIGHTS", "1", "2", "3"},
+			command:          []string{"ZINTERSTORE", "ZinterStoreDestinationKey8", "ZinterStoreKey21", "ZinterStoreKey22", "WEIGHTS", "1", "2", "3"},
 			expectedResponse: 0,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 9. Throw an error if there are fewer weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key23": NewSortedSet([]MemberParam{
+				"ZinterStoreKey23": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key24": NewSortedSet([]MemberParam{
+				"ZinterStoreKey24": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 				}),
-				"key25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterStoreKey25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZINTERSTORE", "destination9", "key23", "key24", "key25", "WEIGHTS", "5", "4"},
+			command:          []string{"ZINTERSTORE", "ZinterStoreDestinationKey9", "ZinterStoreKey23", "ZinterStoreKey24", "ZinterStoreKey25", "WEIGHTS", "5", "4"},
 			expectedResponse: 0,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 10. Throw an error if there are no keys provided
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterStoreKey26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterStoreKey27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterStoreKey28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
 			command:          []string{"ZINTERSTORE", "WEIGHTS", "5", "4"},
 			expectedResponse: 0,
@@ -3703,34 +3672,34 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 		{ // 11. Throw an error if any of the provided keys are not sorted sets
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key29": NewSortedSet([]MemberParam{
+				"ZinterStoreKey29": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key30": "Default value",
-				"key31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZinterStoreKey30": "Default value",
+				"ZinterStoreKey31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZINTERSTORE", "key29", "key30", "key31"},
+			command:          []string{"ZINTERSTORE", "ZinterStoreKey29", "ZinterStoreKey30", "ZinterStoreKey31"},
 			expectedResponse: 0,
-			expectedError:    errors.New("value at key30 is not a sorted set"),
+			expectedError:    errors.New("value at ZinterStoreKey30 is not a sorted set"),
 		},
 		{ // 12. If any of the keys does not exist, return an empty array.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key32": NewSortedSet([]MemberParam{
+				"ZinterStoreKey32": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key33": NewSortedSet([]MemberParam{
+				"ZinterStoreKey33": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command:          []string{"ZINTERSTORE", "destination12", "non-existent", "key32", "key33"},
+			command:          []string{"ZINTERSTORE", "ZinterStoreDestinationKey12", "non-existent", "ZinterStoreKey32", "ZinterStoreKey33"},
 			expectedResponse: 0,
 			expectedError:    nil,
 		},
@@ -3793,8 +3762,6 @@ func Test_HandleZINTERSTORE(t *testing.T) {
 }
 
 func Test_HandleZUNION(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -3805,18 +3772,18 @@ func Test_HandleZUNION(t *testing.T) {
 		{ // 1. Get the union between 2 sorted sets.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZunionKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
-				"key2": NewSortedSet([]MemberParam{
+				"ZunionKey2": NewSortedSet([]MemberParam{
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			command:          []string{"ZUNION", "key1", "key2"},
+			command:          []string{"ZUNION", "ZunionKey1", "ZunionKey2"},
 			expectedResponse: [][]string{{"one"}, {"two"}, {"three"}, {"four"}, {"five"}, {"six"}, {"seven"}, {"eight"}},
 			expectedError:    nil,
 		},
@@ -3825,24 +3792,24 @@ func Test_HandleZUNION(t *testing.T) {
 			// By default, the SUM aggregate will be used.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZunionKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key4": NewSortedSet([]MemberParam{
+				"ZunionKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 8},
 				}),
-				"key5": NewSortedSet([]MemberParam{
+				"ZunionKey5": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12}, {value: "thirty-six", score: 36},
 				}),
 			},
-			command: []string{"ZUNION", "key3", "key4", "key5", "WITHSCORES"},
+			command: []string{"ZUNION", "ZunionKey3", "ZunionKey4", "ZunionKey5", "WITHSCORES"},
 			expectedResponse: [][]string{
 				{"one", "3"}, {"two", "4"}, {"three", "3"}, {"four", "4"}, {"five", "5"}, {"six", "6"},
 				{"seven", "7"}, {"eight", "24"}, {"nine", "9"}, {"ten", "10"}, {"eleven", "11"},
@@ -3855,24 +3822,24 @@ func Test_HandleZUNION(t *testing.T) {
 			// Use MIN aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZunionKey6": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key7": NewSortedSet([]MemberParam{
+				"ZunionKey7": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key8": NewSortedSet([]MemberParam{
+				"ZunionKey8": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12}, {value: "thirty-six", score: 72},
 				}),
 			},
-			command: []string{"ZUNION", "key6", "key7", "key8", "WITHSCORES", "AGGREGATE", "MIN"},
+			command: []string{"ZUNION", "ZunionKey6", "ZunionKey7", "ZunionKey8", "WITHSCORES", "AGGREGATE", "MIN"},
 			expectedResponse: [][]string{
 				{"one", "1"}, {"two", "2"}, {"three", "3"}, {"four", "4"}, {"five", "5"}, {"six", "6"},
 				{"seven", "7"}, {"eight", "8"}, {"nine", "9"}, {"ten", "10"}, {"eleven", "11"},
@@ -3885,24 +3852,24 @@ func Test_HandleZUNION(t *testing.T) {
 			// Use MAX aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": NewSortedSet([]MemberParam{
+				"ZunionKey9": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key10": NewSortedSet([]MemberParam{
+				"ZunionKey10": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZunionKey11": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12}, {value: "thirty-six", score: 72},
 				}),
 			},
-			command: []string{"ZUNION", "key9", "key10", "key11", "WITHSCORES", "AGGREGATE", "MAX"},
+			command: []string{"ZUNION", "ZunionKey9", "ZunionKey10", "ZunionKey11", "WITHSCORES", "AGGREGATE", "MAX"},
 			expectedResponse: [][]string{
 				{"one", "1000"}, {"two", "2"}, {"three", "3"}, {"four", "4"}, {"five", "5"}, {"six", "6"},
 				{"seven", "7"}, {"eight", "800"}, {"nine", "9"}, {"ten", "10"}, {"eleven", "11"},
@@ -3915,24 +3882,24 @@ func Test_HandleZUNION(t *testing.T) {
 			// Use SUM aggregate with weights modifier.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key12": NewSortedSet([]MemberParam{
+				"ZunionKey12": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key13": NewSortedSet([]MemberParam{
+				"ZunionKey13": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key14": NewSortedSet([]MemberParam{
+				"ZunionKey14": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command: []string{"ZUNION", "key12", "key13", "key14", "WITHSCORES", "AGGREGATE", "SUM", "WEIGHTS", "1", "2", "3"},
+			command: []string{"ZUNION", "ZunionKey12", "ZunionKey13", "ZunionKey14", "WITHSCORES", "AGGREGATE", "SUM", "WEIGHTS", "1", "2", "3"},
 			expectedResponse: [][]string{
 				{"one", "3102"}, {"two", "6"}, {"three", "3"}, {"four", "4"}, {"five", "5"}, {"six", "6"},
 				{"seven", "7"}, {"eight", "2568"}, {"nine", "27"}, {"ten", "30"}, {"eleven", "22"},
@@ -3945,24 +3912,24 @@ func Test_HandleZUNION(t *testing.T) {
 			// Use MAX aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key15": NewSortedSet([]MemberParam{
+				"ZunionKey15": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key16": NewSortedSet([]MemberParam{
+				"ZunionKey16": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key17": NewSortedSet([]MemberParam{
+				"ZunionKey17": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command: []string{"ZUNION", "key15", "key16", "key17", "WITHSCORES", "AGGREGATE", "MAX", "WEIGHTS", "1", "2", "3"},
+			command: []string{"ZUNION", "ZunionKey15", "ZunionKey16", "ZunionKey17", "WITHSCORES", "AGGREGATE", "MAX", "WEIGHTS", "1", "2", "3"},
 			expectedResponse: [][]string{
 				{"one", "3000"}, {"two", "4"}, {"three", "3"}, {"four", "4"}, {"five", "5"}, {"six", "6"},
 				{"seven", "7"}, {"eight", "2400"}, {"nine", "27"}, {"ten", "30"}, {"eleven", "22"},
@@ -3975,24 +3942,24 @@ func Test_HandleZUNION(t *testing.T) {
 			// Use MIN aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key18": NewSortedSet([]MemberParam{
+				"ZunionKey18": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key19": NewSortedSet([]MemberParam{
+				"ZunionKey19": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key20": NewSortedSet([]MemberParam{
+				"ZunionKey20": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command: []string{"ZUNION", "key18", "key19", "key20", "WITHSCORES", "AGGREGATE", "MIN", "WEIGHTS", "1", "2", "3"},
+			command: []string{"ZUNION", "ZunionKey18", "ZunionKey19", "ZunionKey20", "WITHSCORES", "AGGREGATE", "MIN", "WEIGHTS", "1", "2", "3"},
 			expectedResponse: [][]string{
 				{"one", "2"}, {"two", "2"}, {"three", "3"}, {"four", "4"}, {"five", "5"}, {"six", "6"}, {"seven", "7"},
 				{"eight", "8"}, {"nine", "27"}, {"ten", "30"}, {"eleven", "22"}, {"twelve", "24"}, {"thirty-six", "72"},
@@ -4002,42 +3969,42 @@ func Test_HandleZUNION(t *testing.T) {
 		{ // 8. Throw an error if there are more weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key21": NewSortedSet([]MemberParam{
+				"ZunionKey21": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionKey22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZUNION", "key21", "key22", "WEIGHTS", "1", "2", "3"},
+			command:          []string{"ZUNION", "ZunionKey21", "ZunionKey22", "WEIGHTS", "1", "2", "3"},
 			expectedResponse: nil,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 9. Throw an error if there are fewer weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key23": NewSortedSet([]MemberParam{
+				"ZunionKey23": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key24": NewSortedSet([]MemberParam{
+				"ZunionKey24": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 				}),
-				"key25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionKey25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZUNION", "key23", "key24", "key25", "WEIGHTS", "5", "4"},
+			command:          []string{"ZUNION", "ZunionKey23", "ZunionKey24", "ZunionKey25", "WEIGHTS", "5", "4"},
 			expectedResponse: nil,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 10. Throw an error if there are no keys provided
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionKey26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionKey27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionKey28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
 			command:          []string{"ZUNION", "WEIGHTS", "5", "4"},
 			expectedResponse: nil,
@@ -4046,34 +4013,34 @@ func Test_HandleZUNION(t *testing.T) {
 		{ // 11. Throw an error if any of the provided keys are not sorted sets
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key29": NewSortedSet([]MemberParam{
+				"ZunionKey29": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key30": "Default value",
-				"key31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionKey30": "Default value",
+				"ZunionKey31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			command:          []string{"ZUNION", "key29", "key30", "key31"},
+			command:          []string{"ZUNION", "ZunionKey29", "ZunionKey30", "ZunionKey31"},
 			expectedResponse: nil,
-			expectedError:    errors.New("value at key30 is not a sorted set"),
+			expectedError:    errors.New("value at ZunionKey30 is not a sorted set"),
 		},
 		{ // 12. If any of the keys does not exist, skip it.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key32": NewSortedSet([]MemberParam{
+				"ZunionKey32": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key33": NewSortedSet([]MemberParam{
+				"ZunionKey33": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			command: []string{"ZUNION", "non-existent", "key32", "key33"},
+			command: []string{"ZUNION", "non-existent", "ZunionKey32", "ZunionKey33"},
 			expectedResponse: [][]string{
 				{"one"}, {"two"}, {"thirty-six"}, {"twelve"}, {"eleven"},
 				{"seven"}, {"eight"}, {"nine"}, {"ten"},
@@ -4136,8 +4103,6 @@ func Test_HandleZUNION(t *testing.T) {
 }
 
 func Test_HandleZUNIONSTORE(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		presetValues     map[string]interface{}
@@ -4150,19 +4115,19 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 		{ // 1. Get the union between 2 sorted sets.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key1": NewSortedSet([]MemberParam{
+				"ZunionStoreKey1": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5},
 				}),
-				"key2": NewSortedSet([]MemberParam{
+				"ZunionStoreKey2": NewSortedSet([]MemberParam{
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
 			},
-			destination: "destination1",
-			command:     []string{"ZUNIONSTORE", "destination1", "key1", "key2"},
+			destination: "ZunionStoreDestinationKey1",
+			command:     []string{"ZUNIONSTORE", "ZunionStoreDestinationKey1", "ZunionStoreKey1", "ZunionStoreKey2"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "two", score: 2},
 				{value: "three", score: 3}, {value: "four", score: 4},
@@ -4177,25 +4142,25 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 			// By default, the SUM aggregate will be used.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key3": NewSortedSet([]MemberParam{
+				"ZunionStoreKey3": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key4": NewSortedSet([]MemberParam{
+				"ZunionStoreKey4": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 8},
 				}),
-				"key5": NewSortedSet([]MemberParam{
+				"ZunionStoreKey5": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12}, {value: "thirty-six", score: 36},
 				}),
 			},
-			destination: "destination2",
-			command:     []string{"ZUNIONSTORE", "destination2", "key3", "key4", "key5", "WITHSCORES"},
+			destination: "ZunionStoreDestinationKey2",
+			command:     []string{"ZUNIONSTORE", "ZunionStoreDestinationKey2", "ZunionStoreKey3", "ZunionStoreKey4", "ZunionStoreKey5", "WITHSCORES"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 3}, {value: "two", score: 4}, {value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5}, {value: "six", score: 6}, {value: "seven", score: 7}, {value: "eight", score: 24},
@@ -4210,25 +4175,25 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 			// Use MIN aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key6": NewSortedSet([]MemberParam{
+				"ZunionStoreKey6": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key7": NewSortedSet([]MemberParam{
+				"ZunionStoreKey7": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key8": NewSortedSet([]MemberParam{
+				"ZunionStoreKey8": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12}, {value: "thirty-six", score: 72},
 				}),
 			},
-			destination: "destination3",
-			command:     []string{"ZUNIONSTORE", "destination3", "key6", "key7", "key8", "WITHSCORES", "AGGREGATE", "MIN"},
+			destination: "ZunionStoreDestinationKey3",
+			command:     []string{"ZUNIONSTORE", "ZunionStoreDestinationKey3", "ZunionStoreKey6", "ZunionStoreKey7", "ZunionStoreKey8", "WITHSCORES", "AGGREGATE", "MIN"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "two", score: 2}, {value: "three", score: 3}, {value: "four", score: 4},
 				{value: "five", score: 5}, {value: "six", score: 6}, {value: "seven", score: 7}, {value: "eight", score: 8},
@@ -4243,26 +4208,26 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 			// Use MAX aggregate.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key9": NewSortedSet([]MemberParam{
+				"ZunionStoreKey9": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key10": NewSortedSet([]MemberParam{
+				"ZunionStoreKey10": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key11": NewSortedSet([]MemberParam{
+				"ZunionStoreKey11": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12}, {value: "thirty-six", score: 72},
 				}),
 			},
-			destination: "destination4",
+			destination: "ZunionStoreDestinationKey4",
 			command: []string{
-				"ZUNIONSTORE", "destination4", "key9", "key10", "key11", "WITHSCORES", "AGGREGATE", "MAX",
+				"ZUNIONSTORE", "ZunionStoreDestinationKey4", "ZunionStoreKey9", "ZunionStoreKey10", "ZunionStoreKey11", "WITHSCORES", "AGGREGATE", "MAX",
 			},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1000}, {value: "two", score: 2}, {value: "three", score: 3}, {value: "four", score: 4},
@@ -4278,26 +4243,26 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 			// Use SUM aggregate with weights modifier.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key12": NewSortedSet([]MemberParam{
+				"ZunionStoreKey12": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key13": NewSortedSet([]MemberParam{
+				"ZunionStoreKey13": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key14": NewSortedSet([]MemberParam{
+				"ZunionStoreKey14": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination5",
+			destination: "ZunionStoreDestinationKey5",
 			command: []string{
-				"ZUNIONSTORE", "destination5", "key12", "key13", "key14",
+				"ZUNIONSTORE", "ZunionStoreDestinationKey5", "ZunionStoreKey12", "ZunionStoreKey13", "ZunionStoreKey14",
 				"WITHSCORES", "AGGREGATE", "SUM", "WEIGHTS", "1", "2", "3",
 			},
 			expectedValue: NewSortedSet([]MemberParam{
@@ -4314,26 +4279,26 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 			// Use MAX aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key15": NewSortedSet([]MemberParam{
+				"ZunionStoreKey15": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key16": NewSortedSet([]MemberParam{
+				"ZunionStoreKey16": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key17": NewSortedSet([]MemberParam{
+				"ZunionStoreKey17": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination6",
+			destination: "ZunionStoreDestinationKey6",
 			command: []string{
-				"ZUNIONSTORE", "destination6", "key15", "key16", "key17",
+				"ZUNIONSTORE", "ZunionStoreDestinationKey6", "ZunionStoreKey15", "ZunionStoreKey16", "ZunionStoreKey17",
 				"WITHSCORES", "AGGREGATE", "MAX", "WEIGHTS", "1", "2", "3"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 3000}, {value: "two", score: 4}, {value: "three", score: 3}, {value: "four", score: 4},
@@ -4349,26 +4314,26 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 			// Use MIN aggregate with added weights.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key18": NewSortedSet([]MemberParam{
+				"ZunionStoreKey18": NewSortedSet([]MemberParam{
 					{value: "one", score: 100}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key19": NewSortedSet([]MemberParam{
+				"ZunionStoreKey19": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11}, {value: "eight", score: 80},
 				}),
-				"key20": NewSortedSet([]MemberParam{
+				"ZunionStoreKey20": NewSortedSet([]MemberParam{
 					{value: "one", score: 1000}, {value: "eight", score: 800},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination7",
+			destination: "ZunionStoreDestinationKey7",
 			command: []string{
-				"ZUNIONSTORE", "destination7", "key18", "key19", "key20",
+				"ZUNIONSTORE", "ZunionStoreDestinationKey7", "ZunionStoreKey18", "ZunionStoreKey19", "ZunionStoreKey20",
 				"WITHSCORES", "AGGREGATE", "MIN", "WEIGHTS", "1", "2", "3",
 			},
 			expectedValue: NewSortedSet([]MemberParam{
@@ -4383,44 +4348,44 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 		{ // 8. Throw an error if there are more weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key21": NewSortedSet([]MemberParam{
+				"ZunionStoreKey21": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionStoreKey22": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			destination:      "destination8",
-			command:          []string{"ZUNIONSTORE", "destination8", "key21", "key22", "WEIGHTS", "1", "2", "3"},
+			destination:      "ZunionStoreDestinationKey8",
+			command:          []string{"ZUNIONSTORE", "ZunionStoreDestinationKey8", "ZunionStoreKey21", "ZunionStoreKey22", "WEIGHTS", "1", "2", "3"},
 			expectedResponse: 0,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 9. Throw an error if there are fewer weights than keys
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key23": NewSortedSet([]MemberParam{
+				"ZunionStoreKey23": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key24": NewSortedSet([]MemberParam{
+				"ZunionStoreKey24": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 				}),
-				"key25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionStoreKey25": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			destination:      "destination9",
-			command:          []string{"ZUNIONSTORE", "destination9", "key23", "key24", "key25", "WEIGHTS", "5", "4"},
+			destination:      "ZunionStoreDestinationKey9",
+			command:          []string{"ZUNIONSTORE", "ZunionStoreDestinationKey9", "ZunionStoreKey23", "ZunionStoreKey24", "ZunionStoreKey25", "WEIGHTS", "5", "4"},
 			expectedResponse: 0,
 			expectedError:    errors.New("number of weights should match number of keys"),
 		},
 		{ // 10. Throw an error if there are no keys provided
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
-				"key28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionStoreKey26": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionStoreKey27": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionStoreKey28": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
 			command:          []string{"ZUNIONSTORE", "WEIGHTS", "5", "4"},
 			expectedResponse: 0,
@@ -4429,36 +4394,36 @@ func Test_HandleZUNIONSTORE(t *testing.T) {
 		{ // 11. Throw an error if any of the provided keys are not sorted sets
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key29": NewSortedSet([]MemberParam{
+				"ZunionStoreKey29": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "three", score: 3}, {value: "four", score: 4},
 					{value: "five", score: 5}, {value: "six", score: 6},
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 				}),
-				"key30": "Default value",
-				"key31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
+				"ZunionStoreKey30": "Default value",
+				"ZunionStoreKey31": NewSortedSet([]MemberParam{{value: "one", score: 1}}),
 			},
-			destination:      "destination11",
-			command:          []string{"ZUNIONSTORE", "destination11", "key29", "key30", "key31"},
+			destination:      "ZunionStoreDestinationKey11",
+			command:          []string{"ZUNIONSTORE", "ZunionStoreDestinationKey11", "ZunionStoreKey29", "ZunionStoreKey30", "ZunionStoreKey31"},
 			expectedResponse: 0,
-			expectedError:    errors.New("value at key30 is not a sorted set"),
+			expectedError:    errors.New("value at ZunionStoreKey30 is not a sorted set"),
 		},
 		{ // 12. If any of the keys does not exist, skip it.
 			preset: true,
 			presetValues: map[string]interface{}{
-				"key32": NewSortedSet([]MemberParam{
+				"ZunionStoreKey32": NewSortedSet([]MemberParam{
 					{value: "one", score: 1}, {value: "two", score: 2},
 					{value: "thirty-six", score: 36}, {value: "twelve", score: 12},
 					{value: "eleven", score: 11},
 				}),
-				"key33": NewSortedSet([]MemberParam{
+				"ZunionStoreKey33": NewSortedSet([]MemberParam{
 					{value: "seven", score: 7}, {value: "eight", score: 8},
 					{value: "nine", score: 9}, {value: "ten", score: 10},
 					{value: "twelve", score: 12},
 				}),
 			},
-			destination: "destination12",
-			command:     []string{"ZUNIONSTORE", "destination12", "non-existent", "key32", "key33"},
+			destination: "ZunionStoreDestinationKey12",
+			command:     []string{"ZUNIONSTORE", "ZunionStoreDestinationKey12", "non-existent", "ZunionStoreKey32", "ZunionStoreKey33"},
 			expectedValue: NewSortedSet([]MemberParam{
 				{value: "one", score: 1}, {value: "two", score: 2}, {value: "seven", score: 7}, {value: "eight", score: 8},
 				{value: "nine", score: 9}, {value: "ten", score: 10}, {value: "eleven", score: 11}, {value: "twelve", score: 12},

--- a/src/modules/string/commands_test.go
+++ b/src/modules/string/commands_test.go
@@ -12,9 +12,18 @@ import (
 	"testing"
 )
 
-func Test_HandleSetRange(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
+var mockServer *server.Server
 
+func init() {
+	mockServer = server.NewServer(server.Opts{
+		Config: utils.Config{
+			DataDir:        "",
+			EvictionPolicy: utils.NoEviction,
+		},
+	})
+}
+
+func Test_HandleSetRange(t *testing.T) {
 	tests := []struct {
 		preset           bool
 		key              string
@@ -26,54 +35,54 @@ func Test_HandleSetRange(t *testing.T) {
 	}{
 		{ // Test that SETRANGE on non-existent string creates new string
 			preset:           false,
-			key:              "test1",
+			key:              "SetRangeKey1",
 			presetValue:      "",
-			command:          []string{"SETRANGE", "test1", "10", "New String Value"},
+			command:          []string{"SETRANGE", "SetRangeKey1", "10", "New String Value"},
 			expectedValue:    "New String Value",
 			expectedResponse: len("New String Value"),
 			expectedError:    nil,
 		},
 		{ // Test SETRANGE with an offset that leads to a longer resulting string
 			preset:           true,
-			key:              "test2",
+			key:              "SetRangeKey2",
 			presetValue:      "Original String Value",
-			command:          []string{"SETRANGE", "test2", "16", "Portion Replaced With This New String"},
+			command:          []string{"SETRANGE", "SetRangeKey2", "16", "Portion Replaced With This New String"},
 			expectedValue:    "Original String Portion Replaced With This New String",
 			expectedResponse: len("Original String Portion Replaced With This New String"),
 			expectedError:    nil,
 		},
 		{ // SETRANGE with negative offset prepends the string
 			preset:           true,
-			key:              "test3",
+			key:              "SetRangeKey3",
 			presetValue:      "This is a preset value",
-			command:          []string{"SETRANGE", "test3", "-10", "Prepended "},
+			command:          []string{"SETRANGE", "SetRangeKey3", "-10", "Prepended "},
 			expectedValue:    "Prepended This is a preset value",
 			expectedResponse: len("Prepended This is a preset value"),
 			expectedError:    nil,
 		},
 		{ // SETRANGE with offset that embeds new string inside the old string
 			preset:           true,
-			key:              "test4",
+			key:              "SetRangeKey4",
 			presetValue:      "This is a preset value",
-			command:          []string{"SETRANGE", "test4", "0", "That"},
+			command:          []string{"SETRANGE", "SetRangeKey4", "0", "That"},
 			expectedValue:    "That is a preset value",
 			expectedResponse: len("That is a preset value"),
 			expectedError:    nil,
 		},
 		{ // SETRANGE with offset longer than original lengths appends the string
 			preset:           true,
-			key:              "test5",
+			key:              "SetRangeKey5",
 			presetValue:      "This is a preset value",
-			command:          []string{"SETRANGE", "test5", "100", " Appended"},
+			command:          []string{"SETRANGE", "SetRangeKey5", "100", " Appended"},
 			expectedValue:    "This is a preset value Appended",
 			expectedResponse: len("This is a preset value Appended"),
 			expectedError:    nil,
 		},
 		{ // SETRANGE with offset on the last character replaces last character with new string
 			preset:           true,
-			key:              "test6",
+			key:              "SetRangeKey6",
 			presetValue:      "This is a preset value",
-			command:          []string{"SETRANGE", "test6", strconv.Itoa(len("This is a preset value") - 1), " replaced"},
+			command:          []string{"SETRANGE", "SetRangeKey6", strconv.Itoa(len("This is a preset value") - 1), " replaced"},
 			expectedValue:    "This is a preset valu replaced",
 			expectedResponse: len("This is a preset valu replaced"),
 			expectedError:    nil,
@@ -155,8 +164,6 @@ func Test_HandleSetRange(t *testing.T) {
 }
 
 func Test_HandleStrLen(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -167,23 +174,23 @@ func Test_HandleStrLen(t *testing.T) {
 	}{
 		{ // Return the correct string length for an existing string
 			preset:           true,
-			key:              "test1",
+			key:              "StrLenKey1",
 			presetValue:      "Test String",
-			command:          []string{"STRLEN", "test1"},
+			command:          []string{"STRLEN", "StrLenKey1"},
 			expectedResponse: len("Test String"),
 			expectedError:    nil,
 		},
 		{ // If the string does not exist, return 0
 			preset:           false,
-			key:              "test2",
+			key:              "StrLenKey2",
 			presetValue:      "",
-			command:          []string{"STRLEN", "test2"},
+			command:          []string{"STRLEN", "StrLenKey2"},
 			expectedResponse: 0,
 			expectedError:    nil,
 		},
 		{ // Too few args
 			preset:           false,
-			key:              "test3",
+			key:              "StrLenKey3",
 			presetValue:      "",
 			command:          []string{"STRLEN"},
 			expectedResponse: 0,
@@ -191,9 +198,9 @@ func Test_HandleStrLen(t *testing.T) {
 		},
 		{ // Too many args
 			preset:           false,
-			key:              "test4",
+			key:              "StrLenKey4",
 			presetValue:      "",
-			command:          []string{"STRLEN", "test4", "test5"},
+			command:          []string{"STRLEN", "StrLenKey4", "StrLenKey5"},
 			expectedResponse: 0,
 			expectedError:    errors.New(utils.WrongArgsResponse),
 		},
@@ -231,8 +238,6 @@ func Test_HandleStrLen(t *testing.T) {
 }
 
 func Test_HandleSubStr(t *testing.T) {
-	mockServer := server.NewServer(server.Opts{})
-
 	tests := []struct {
 		preset           bool
 		key              string
@@ -243,33 +248,33 @@ func Test_HandleSubStr(t *testing.T) {
 	}{
 		{ // Return substring within the range of the string
 			preset:           true,
-			key:              "test1",
+			key:              "SubStrKey1",
 			presetValue:      "Test String One",
-			command:          []string{"SUBSTR", "test1", "5", "10"},
+			command:          []string{"SUBSTR", "SubStrKey1", "5", "10"},
 			expectedResponse: "String",
 			expectedError:    nil,
 		},
 		{ // Return substring at the end of the string with exact end index
 			preset:           true,
-			key:              "test2",
+			key:              "SubStrKey2",
 			presetValue:      "Test String Two",
-			command:          []string{"SUBSTR", "test2", "12", "14"},
+			command:          []string{"SUBSTR", "SubStrKey2", "12", "14"},
 			expectedResponse: "Two",
 			expectedError:    nil,
 		},
 		{ // Return substring at the end of the string with end index greater than length
 			preset:           true,
-			key:              "test3",
+			key:              "SubStrKey3",
 			presetValue:      "Test String Three",
-			command:          []string{"SUBSTR", "test3", "12", "75"},
+			command:          []string{"SUBSTR", "SubStrKey3", "12", "75"},
 			expectedResponse: "Three",
 			expectedError:    nil,
 		},
 		{ // Return the substring at the start of the string with 0 start index
 			preset:           true,
-			key:              "test4",
+			key:              "SubStrKey4",
 			presetValue:      "Test String Four",
-			command:          []string{"SUBSTR", "test4", "0", "3"},
+			command:          []string{"SUBSTR", "SubStrKey4", "0", "3"},
 			expectedResponse: "Test",
 			expectedError:    nil,
 		},
@@ -277,9 +282,9 @@ func Test_HandleSubStr(t *testing.T) {
 			// Return the substring with negative start index.
 			// Substring should begin abs(start) from the end of the string when start is negative.
 			preset:           true,
-			key:              "test5",
+			key:              "SubStrKey5",
 			presetValue:      "Test String Five",
-			command:          []string{"SUBSTR", "test5", "-11", "10"},
+			command:          []string{"SUBSTR", "SubStrKey5", "-11", "10"},
 			expectedResponse: "String",
 			expectedError:    nil,
 		},
@@ -287,9 +292,9 @@ func Test_HandleSubStr(t *testing.T) {
 			// Return reverse substring with end index smaller than start index.
 			// When end index is smaller than start index, the 2 indices are reversed.
 			preset:           true,
-			key:              "test6",
+			key:              "SubStrKey6",
 			presetValue:      "Test String Six",
-			command:          []string{"SUBSTR", "test6", "4", "0"},
+			command:          []string{"SUBSTR", "SubStrKey6", "4", "0"},
 			expectedResponse: "tseT",
 			expectedError:    nil,
 		},

--- a/src/server/modules.go
+++ b/src/server/modules.go
@@ -51,9 +51,11 @@ func (server *Server) handleCommand(ctx context.Context, message []byte, conn *n
 	}
 
 	if conn != nil {
-		// Authorize connection if it's provided
-		if err = server.ACL.AuthorizeConnection(conn, cmd, command, subCommand); err != nil {
-			return nil, err
+		// Authorize connection if it's provided and if ACL module is present
+		if server.ACL != nil {
+			if err = server.ACL.AuthorizeConnection(conn, cmd, command, subCommand); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -261,7 +261,10 @@ func (server *Server) StartTCP(ctx context.Context) {
 }
 
 func (server *Server) handleConnection(ctx context.Context, conn net.Conn) {
-	server.ACL.RegisterConnection(&conn)
+	// If ACL module is loaded, register the connection with the ACL
+	if server.ACL != nil {
+		server.ACL.RegisterConnection(&conn)
+	}
 
 	w, r := io.Writer(conn), io.Reader(conn)
 


### PR DESCRIPTION
This PR introduces unit tests for all the currently available PUBSUB commands.

The change also introduces some bug fixes for the following issues:

1) The server would not return the response expected by the Redis client when subscribing to channels and patterns.
2) NUMPAT and NUMSUB commands would sometimes return the wrong number of patterns or channel subscribers active.
3) Sometimes, messages would not be sent to subscribers as the pub-sub module would hang after subscribing.
4) Introduces more RWMutex locking/unlocking in receiver functions to improve concurrent flow control.