### PR TITLE
Updating Dockerfile.dev to use multi stage build for creating binarys

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,13 @@
-FROM --platform=linux/amd64 alpine:latest
+FROM --platform=linux/amd64 golang:alpine as build
+
+RUN apk add --no-cache musl-dev
+WORKDIR /build
+COPY . ./
+ENV CGO_ENABLED=1 CC=x86_64-linux-musl-gcc GOOS=linux GOARCH=amd64 
+ENV DEST=volumes/modules
+RUN  CGO_ENABLED=$CGO_ENABLED CC=$CC GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -o $DEST/module_set/module_set.so ./volumes/modules/module_set/module_set.go 
+
+FROM --platform=linux/amd64 build
 
 RUN mkdir -p /usr/local/lib/echovault
 RUN mkdir -p /opt/echovault/bin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -46,7 +46,6 @@ CMD "./server" \
   "--eviction-interval" "${EVICTION_INTERVAL}" \
   "--tls=${TLS}" \
   "--mtls=${MTLS}" \
-  "--in-memory=${IN_MEMORY}" \
   "--bootstrap-cluster=${BOOTSTRAP_CLUSTER}" \
   "--acl-config=${ACL_CONFIG}" \
   "--require-pass=${REQUIRE_PASS}" \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,20 +1,30 @@
 FROM --platform=linux/amd64 golang:alpine as build
 
-RUN apk add --no-cache musl-dev
+RUN apk add --no-cache gcc musl-dev
+
 WORKDIR /build
 COPY . ./
-ENV CGO_ENABLED=1 CC=x86_64-linux-musl-gcc GOOS=linux GOARCH=amd64 
+
+ENV CGO_ENABLED=1 CC=gcc GOOS=linux GOARCH=amd64 
+
 ENV DEST=volumes/modules
 RUN  CGO_ENABLED=$CGO_ENABLED CC=$CC GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -o $DEST/module_set/module_set.so ./volumes/modules/module_set/module_set.go 
+RUN CGO_ENABLED=$CGO_ENABLED CC=$CC GOOS=$GOOS GOARCH=$GOARCH go build -buildmode=plugin -o $DEST/module_get/module_get.so ./volumes/modules/module_get/module_get.go
 
-FROM --platform=linux/amd64 build
+ENV DEST=bin/linux/x86_64
+RUN CGO_ENABLED=$CGO_ENABLED CC=$CC GOOS=$GOOS GOARCH=$GOARCH go build -o $DEST/server ./cmd/main.go
+
+
+
+FROM --platform=linux/amd64 alpine:latest as server
 
 RUN mkdir -p /usr/local/lib/echovault
 RUN mkdir -p /opt/echovault/bin
 RUN mkdir -p /etc/ssl/certs/echovault/echovault
 RUN mkdir -p /etc/ssl/certs/echovault/client
 
-COPY ./bin/linux/x86_64/server /opt/echovault/bin
+COPY --from=build /build/bin/linux/x86_64/server /opt/echovault/bin
+
 COPY ./openssl/server /etc/ssl/certs/echovault/server
 COPY ./openssl/client /etc/ssl/certs/echovault/client
 


### PR DESCRIPTION
resolves #49 

Updates Dockerfile.dev to use a multi-staged approach to building the binaries for EchoVault. This means developers will not need to build the binaries locally before using Dockerfile.dev. 