### PR TITLE
Testing on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test-race:
 	env RACE=true OUT=echovault/testdata make build-modules-test && \
 	CGO_ENABLED=1 go test ./... --race
 
+test-win:
+	docker-compose -f windows_test_env/docker-compose.yaml up
+
 cover:
 	go tool cover -html=./coverage/coverage.out
 

--- a/windows_test_env/Dockerfile
+++ b/windows_test_env/Dockerfile
@@ -1,0 +1,8 @@
+# run docker-compose from root dir
+FROM golang:latest
+
+WORKDIR /testspace
+
+COPY . ./
+
+CMD make test; make test-race;

--- a/windows_test_env/docker-compose.yaml
+++ b/windows_test_env/docker-compose.yaml
@@ -1,0 +1,10 @@
+# run from root dir
+services:
+  test:
+    build: 
+      context: ..
+      dockerfile: windows_test_env/Dockerfile
+    container_name: EchoVault_win_test_env
+    stdin_open: true
+    tty: true
+


### PR DESCRIPTION
Problem: 
Running tests in a windows environment fails with an error message containing `-buildmode=plugin not supported on windows/amd64`.

Solution:
Added testing support for windows by using a docker container to run tests out of.

This includes:
- windows_test_env dir containing a Dockerfile and docker-compose.yaml.
- additional command in makefile `test-win`.

`make test-win` will spin up a docker container in interactive mode and  automagically run `make test` and `make test-race` in sequence for you.