### PR TITLE
Iss 68 implement GETDEL command

### DIFF
--- a/echovault/api_generic.go
+++ b/echovault/api_generic.go
@@ -562,3 +562,19 @@ func (server *EchoVault) RandomKey() (string, error) {
 	}
 	return internal.ParseStringResponse(b)
 }
+
+// GetDel retrieves the value at the provided key and deletes that key.
+//
+// Parameters:
+//
+// `key` - string - the key whose value should be retrieved and then deleted.
+//
+// Returns: A string representing the value at the specified key. If the value does not exist, an empty
+// string is returned.
+func (server *EchoVault) GetDel(key string) (string, error) {
+	b, err := server.handleCommand(server.context, internal.EncodeCommand([]string{"GETDEL", key}), nil, false, true)
+	if err != nil {
+		return "", err
+	}
+	return internal.ParseStringResponse(b)
+}

--- a/echovault/api_generic_test.go
+++ b/echovault/api_generic_test.go
@@ -1342,3 +1342,61 @@ func TestEchoVault_RANDOMKEY(t *testing.T) {
 	}
 
 }
+
+func TestEchoVault_GETDEL(t *testing.T) {
+	server := createEchoVault()
+
+	tests := []struct {
+		name        string
+		presetValue interface{}
+		key         string
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "Return string from existing key",
+			presetValue: "value1",
+			key:         "key1",
+			want:        "value1",
+			wantErr:     false,
+		},
+		{
+			name:        "Return empty string if the key does not exist",
+			presetValue: nil,
+			key:         "key2",
+			want:        "",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.presetValue != nil {
+				err := presetValue(server, context.Background(), tt.key, tt.presetValue)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+			}
+			//Check value received
+			got, err := server.GetDel(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GETDEL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GETDEL() got = %v, want %v", got, tt.want)
+			}
+			//Check key was deleted
+			if tt.presetValue != nil {
+				got, err := server.Get(tt.key)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("GETDEL() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if got != "" {
+					t.Errorf("GETDEL() got = %v, want empty string", got)
+				}
+			}
+		})
+	}
+}

--- a/echovault/keyspace.go
+++ b/echovault/keyspace.go
@@ -655,9 +655,11 @@ func (server *EchoVault) randomKey(ctx context.Context) string {
 	for key, _ := range server.store[database] {
 		if i == randnum {
 			randkey = key
+			break
 		} else {
 			i++
 		}
+
 	}
 
 	return randkey

--- a/internal/modules/generic/key_funcs.go
+++ b/internal/modules/generic/key_funcs.go
@@ -201,3 +201,14 @@ func randomKeyFunc(cmd []string) (internal.KeyExtractionFuncResult, error) {
 		WriteKeys: make([]string, 0),
 	}, nil
 }
+
+func getDelKeyFunc(cmd []string) (internal.KeyExtractionFuncResult, error) {
+	if len(cmd) != 2 {
+		return internal.KeyExtractionFuncResult{}, errors.New(constants.WrongArgsResponse)
+	}
+	return internal.KeyExtractionFuncResult{
+		Channels:  make([]string, 0),
+		ReadKeys:  cmd[1:],
+		WriteKeys: cmd[1:],
+	}, nil
+}


### PR DESCRIPTION
addresses #68 

adds getdel command
adds GetDel method to generic api

Redis GETDEL says it will [delete the key only if it is a string](https://redis.io/docs/latest/commands/getdel/)... I was unsure of the reasoning behind this, so currently my implementation deletes the key after returning its value regardless of data type (assuming the key exists). I can see use cases for wanting a more atomic "delete after get" option for keys that aren't necessarily string values. Happy to update my PR if needed.

Also added a break to the loop in randomKey method so that every call would not iterate over the entire map every time which would lead to not so random results. 🙃 