### PR TITLE
Add method that allows user to specify `DataDir` directly

### DIFF
--- a/echovault/config.go
+++ b/echovault/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/echovault/echovault/internal"
 	"github.com/echovault/echovault/internal/config"
 	"github.com/echovault/echovault/internal/constants"
+	"time"
 )
 
 // DefaultConfig returns the default configuration.
@@ -47,5 +48,276 @@ func (server *EchoVault) GetServerInfo() internal.ServerInfo {
 			return "replica"
 		}(),
 		Modules: server.ListModules(),
+	}
+}
+
+// WithTLS is an option to the NewEchoVault function that allows you to pass a
+// custom TLS to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithTLS(b ...bool) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		if len(b) > 0 {
+			echovault.config.TLS = b[0]
+		} else {
+			echovault.config.TLS = true
+		}
+	}
+}
+
+// WithMTLS is an option to the NewEchoVault function that allows you to pass a
+// custom MTLS to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithMTLS(b ...bool) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		if len(b) > 0 {
+			echovault.config.MTLS = b[0]
+		} else {
+			echovault.config.MTLS = true
+		}
+	}
+}
+
+// WithCertKeyPairs is an option to the NewEchoVault function that allows you to pass a
+// custom CertKeyPairs to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithCertKeyPairs(certKeyPairs [][]string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.CertKeyPairs = certKeyPairs
+	}
+}
+
+// WithClientCAs is an option to the NewEchoVault function that allows you to pass a
+// custom ClientCAs to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithClientCAs(clientCAs []string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.ClientCAs = clientCAs
+	}
+}
+
+// WithPort is an option to the NewEchoVault function that allows you to pass a
+// custom Port to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithPort(port uint16) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.Port = port
+	}
+}
+
+// WithServerID is an option to the NewEchoVault function that allows you to pass a
+// custom ServerID to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithServerID(serverID string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.ServerID = serverID
+	}
+}
+
+// WithJoinAddr is an option to the NewEchoVault function that allows you to pass a
+// custom JoinAddr to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithJoinAddr(joinAddr string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.JoinAddr = joinAddr
+	}
+}
+
+// WithBindAddr is an option to the NewEchoVault function that allows you to pass a
+// custom BindAddr to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithBindAddr(bindAddr string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.BindAddr = bindAddr
+	}
+}
+
+// WithDataDir is an option to the NewEchoVault function that allows you to pass a
+// custom DataDir to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithDataDir(dataDir string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.DataDir = dataDir
+	}
+}
+
+// WithBootstrapCluster is an option to the NewEchoVault function that allows you to pass a
+// custom BootstrapCluster to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithBootstrapCluster(b ...bool) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		if len(b) > 0 {
+			echovault.config.BootstrapCluster = b[0]
+		} else {
+			echovault.config.BootstrapCluster = true
+		}
+	}
+}
+
+// WithAclConfig is an option to the NewEchoVault function that allows you to pass a
+// custom AclConfig to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithAclConfig(aclConfig string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.AclConfig = aclConfig
+	}
+}
+
+// WithForwardCommand is an option to the NewEchoVault function that allows you to pass a
+// custom ForwardCommand to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithForwardCommand(b ...bool) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		if len(b) > 0 {
+			echovault.config.ForwardCommand = b[0]
+		} else {
+			echovault.config.ForwardCommand = true
+		}
+	}
+}
+
+// WithRequirePass is an option to the NewEchoVault function that allows you to pass a
+// custom RequirePass to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithRequirePass(b ...bool) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		if len(b) > 0 {
+			echovault.config.RequirePass = b[0]
+		} else {
+			echovault.config.RequirePass = true
+		}
+	}
+}
+
+// WithPassword is an option to the NewEchoVault function that allows you to pass a
+// custom Password to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithPassword(password string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.Password = password
+	}
+}
+
+// WithSnapShotThreshold is an option to the NewEchoVault function that allows you to pass a
+// custom SnapShotThreshold to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithSnapShotThreshold(snapShotThreshold uint64) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.SnapShotThreshold = snapShotThreshold
+	}
+}
+
+// WithSnapshotInterval is an option to the NewEchoVault function that allows you to pass a
+// custom SnapshotInterval to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithSnapshotInterval(snapshotInterval time.Duration) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.SnapshotInterval = snapshotInterval
+	}
+}
+
+// WithRestoreSnapshot is an option to the NewEchoVault function that allows you to pass a
+// custom RestoreSnapshot to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithRestoreSnapshot(b ...bool) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		if len(b) > 0 {
+			echovault.config.RestoreSnapshot = b[0]
+		} else {
+			echovault.config.RestoreSnapshot = true
+		}
+	}
+}
+
+// WithRestoreAOF is an option to the NewEchoVault function that allows you to pass a
+// custom RestoreAOF to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithRestoreAOF(b ...bool) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		if len(b) > 0 {
+			echovault.config.RestoreAOF = b[0]
+		} else {
+			echovault.config.RestoreAOF = true
+		}
+	}
+}
+
+// WithAOFSyncStrategy is an option to the NewEchoVault function that allows you to pass a
+// custom AOFSyncStrategy to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithAOFSyncStrategy(aOFSyncStrategy string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.AOFSyncStrategy = aOFSyncStrategy
+	}
+}
+
+// WithMaxMemory is an option to the NewEchoVault function that allows you to pass a
+// custom MaxMemory to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithMaxMemory(maxMemory uint64) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.MaxMemory = maxMemory
+	}
+}
+
+// WithEvictionPolicy is an option to the NewEchoVault function that allows you to pass a
+// custom EvictionPolicy to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithEvictionPolicy(evictionPolicy string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.EvictionPolicy = evictionPolicy
+	}
+}
+
+// WithEvictionSample is an option to the NewEchoVault function that allows you to pass a
+// custom EvictionSample to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithEvictionSample(evictionSample uint) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.EvictionSample = evictionSample
+	}
+}
+
+// WithEvictionInterval is an option to the NewEchoVault function that allows you to pass a
+// custom EvictionInterval to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithEvictionInterval(evictionInterval time.Duration) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.EvictionInterval = evictionInterval
+	}
+}
+
+// WithModules is an option to the NewEchoVault function that allows you to pass a
+// custom Modules to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithModules(modules []string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.Modules = modules
+	}
+}
+
+// WithDiscoveryPort is an option to the NewEchoVault function that allows you to pass a
+// custom DiscoveryPort to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithDiscoveryPort(discoveryPort uint16) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.DiscoveryPort = discoveryPort
+	}
+}
+
+// WithRaftBindAddr is an option to the NewEchoVault function that allows you to pass a
+// custom RaftBindAddr to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithRaftBindAddr(raftBindAddr string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.RaftBindAddr = raftBindAddr
+	}
+}
+
+// WithRaftBindPort is an option to the NewEchoVault function that allows you to pass a
+// custom RaftBindPort to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithRaftBindPort(raftBindPort uint16) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.RaftBindPort = raftBindPort
 	}
 }

--- a/echovault/echovault.go
+++ b/echovault/echovault.go
@@ -140,15 +140,6 @@ func WithConfig(config config.Config) func(echovault *EchoVault) {
 	}
 }
 
-// WithDataDir is an option to the NewEchoVault function that allows you to pass a
-// custom DataDir to EchoVault.
-// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
-func WithDataDir(dataDir string) func(echovault *EchoVault) {
-	return func(echovault *EchoVault) {
-		echovault.config.DataDir = dataDir
-	}
-}
-
 // NewEchoVault creates a new EchoVault instance.
 // This functions accepts the WithContext, WithConfig and WithCommands options.
 func NewEchoVault(options ...func(echovault *EchoVault)) (*EchoVault, error) {

--- a/echovault/echovault.go
+++ b/echovault/echovault.go
@@ -140,6 +140,15 @@ func WithConfig(config config.Config) func(echovault *EchoVault) {
 	}
 }
 
+// WithDataDir is an option to the NewEchoVault function that allows you to pass a
+// custom DataDir to EchoVault.
+// If not specified, EchoVault will use the default configuration from config.DefaultConfig().
+func WithDataDir(dataDir string) func(echovault *EchoVault) {
+	return func(echovault *EchoVault) {
+		echovault.config.DataDir = dataDir
+	}
+}
+
 // NewEchoVault creates a new EchoVault instance.
 // This functions accepts the WithContext, WithConfig and WithCommands options.
 func NewEchoVault(options ...func(echovault *EchoVault)) (*EchoVault, error) {


### PR DESCRIPTION
Add a method that allows users to directly specify `DataDir`, simplifying the call path when users only want to change the `DataDir` value